### PR TITLE
ci: add project quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run backend unit tests
+        env:
+          PYTHONPATH: .
+        run: python -m pytest -q
+
+      - name: Compile backend modules
+        run: python -m compileall -q backend
+
+  frontend:
+    name: Frontend tests and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run frontend lint
+        working-directory: frontend
+        run: npm run lint
+
+      - name: Run frontend unit tests
+        working-directory: frontend
+        run: npm test -- --run
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+  frontend-e2e:
+    name: Frontend Playwright smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browser
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright smoke tests
+        working-directory: frontend
+        run: npm run test:e2e -- interactive-artifacts.spec.ts
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  workflow:
+    name: Workflow lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1
+
   backend:
     name: Backend tests
     runs-on: ubuntu-latest
@@ -34,6 +46,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
+          python -m pip install ruff==0.15.20
+
+      - name: Run Ruff
+        run: python -m ruff check backend tests
 
       - name: Run backend unit tests
         env:
@@ -70,6 +86,10 @@ jobs:
       - name: Run frontend unit tests
         working-directory: frontend
         run: npm test -- --run
+
+      - name: Run frontend typecheck
+        working-directory: frontend
+        run: npm run typecheck
 
       - name: Build frontend
         working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+        run: |
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" -o actionlint.tar.gz
+          tar -xzf actionlint.tar.gz actionlint
+          ./actionlint
 
   backend:
     name: Backend tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NotebookLM-Lite
 
+[![CI](https://github.com/LRriver/NotebookLM-Lite/actions/workflows/ci.yml/badge.svg)](https://github.com/LRriver/NotebookLM-Lite/actions/workflows/ci.yml)
+
 [中文](./README_zh.md) | [English](./README.md)
 
 NotebookLM-Lite is an open-source NotebookLM-style AI knowledge workspace for local files, grounded RAG chat, notes, interactive Studio artifacts, and long-form podcast generation. It is built for people who like the Google NotebookLM workflow but want a hackable, self-hosted project with their own model endpoints, their own document pipeline, and a clear backend architecture.

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,5 +1,7 @@
 # NotebookLM-Lite
 
+[![CI](https://github.com/LRriver/NotebookLM-Lite/actions/workflows/ci.yml/badge.svg)](https://github.com/LRriver/NotebookLM-Lite/actions/workflows/ci.yml)
+
 [中文](./README_zh.md) | [English](./README.md)
 
 NotebookLM-Lite 是一个开源的 NotebookLM 风格 AI 知识工作台，用于把本地资料变成可问答、可整理、可生成内容的知识库。它面向长文档阅读、课程学习、论文/手册分析、产品资料整理、播客脚本生成、RAG 应用原型等场景，目标是在一个可自托管、可改造、可接入自定义模型的项目里，复刻大部分 NotebookLM 的核心体验。

--- a/backend/api/schemas/slide_deck.py
+++ b/backend/api/schemas/slide_deck.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from ...domain.slide_deck import SlideDeckOutline, SlidePromptPlanSet, SlideRecord
+from ...domain.slide_deck import SlideDeckOutline, SlidePromptPlanSet
 
 
 class SlideDeckCreateRequest(BaseModel):

--- a/backend/core/interfaces/document_parser.py
+++ b/backend/core/interfaces/document_parser.py
@@ -5,7 +5,7 @@ Abstract interface for document parsing.
 Supports PDF, DOCX, TXT, Markdown, HTML formats.
 """
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 from enum import Enum
 
 

--- a/backend/core/interfaces/llm_provider.py
+++ b/backend/core/interfaces/llm_provider.py
@@ -5,7 +5,7 @@ Abstract interface for Language Model providers.
 Supports OpenAI, Google GenAI (Gemini), and OpenAI-compatible APIs.
 """
 from abc import ABC, abstractmethod
-from typing import Type, TypeVar, List, Dict, Any, Optional
+from typing import Type, TypeVar, List, Optional
 from pydantic import BaseModel
 
 T = TypeVar('T', bound=BaseModel)

--- a/backend/core/interfaces/tts_provider.py
+++ b/backend/core/interfaces/tts_provider.py
@@ -5,7 +5,7 @@ Abstract interface for Text-to-Speech providers.
 Supports OpenAI TTS, Dashscope CosyVoice, and other TTS services.
 """
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 from enum import Enum
 
 

--- a/backend/core/services/document_service.py
+++ b/backend/core/services/document_service.py
@@ -9,7 +9,6 @@ import uuid
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 
 from ..interfaces.vector_store import VectorStoreInterface
-from ..interfaces.document_parser import DocumentParserInterface
 from ...domain.document import ProcessedDocument, DocumentChunk, DocumentType
 from ...infrastructure.parsers.parser_factory import ParserFactory
 

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -5,7 +5,6 @@ Factory methods for creating service instances with proper abstraction.
 Enables easy testing and swapping of implementations.
 """
 from typing import Any, Optional
-from functools import lru_cache
 
 from .config import ModelProfile, Settings, get_settings
 from .core.interfaces.vector_store import VectorStoreInterface

--- a/backend/infrastructure/parsers/docling_parser.py
+++ b/backend/infrastructure/parsers/docling_parser.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import mimetypes
 from pathlib import Path
-from typing import Any
 
 
 class ParsedDocument(dict):

--- a/backend/infrastructure/parsers/parser_factory.py
+++ b/backend/infrastructure/parsers/parser_factory.py
@@ -4,7 +4,7 @@ Parser Factory
 Factory for creating appropriate document parsers based on file type.
 """
 from typing import Dict, Type
-from ...core.interfaces.document_parser import DocumentParserInterface, DocumentType
+from ...core.interfaces.document_parser import DocumentParserInterface
 from .pdf_parser import PDFParser
 from .docx_parser import DocxParser
 from .text_parser import TextParser

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,6 @@ import os
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
 
 from .config import get_settings
 from .api.routes.chat import router as chat_router

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,32 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+    {
+        ignores: ['dist/**', 'node_modules/**', 'coverage/**', 'test-results/**', 'playwright-report/**'],
+    },
+    js.configs.recommended,
+    ...tseslint.configs.recommended,
+    {
+        files: ['**/*.{ts,tsx}'],
+        languageOptions: {
+            ecmaVersion: 2020,
+            globals: {
+                ...globals.browser,
+                ...globals.es2020,
+            },
+        },
+        plugins: {
+            'react-hooks': reactHooks,
+            'react-refresh': reactRefresh,
+        },
+        rules: {
+            ...reactHooks.configs.recommended.rules,
+            '@typescript-eslint/no-explicit-any': 'warn',
+            'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+        },
+    },
+);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,7 +33,6 @@
                 "typescript": "~5.6.2",
                 "typescript-eslint": "^8.11.0",
                 "vite": "^8.0.15",
-                "vite-node": "^4.1.8",
                 "vitest": "^4.1.8"
             }
         },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,6 @@
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.11.0",
         "vite": "^8.0.15",
-        "vite-node": "^4.1.8",
         "vitest": "^4.1.8"
     }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
         "test": "vitest run",
         "test:e2e": "playwright test",
         "lint": "eslint .",
+        "typecheck": "tsc -b",
         "preview": "vite preview"
     },
     "dependencies": {

--- a/tests/test_slide_deck_domain_repository.py
+++ b/tests/test_slide_deck_domain_repository.py
@@ -25,7 +25,7 @@ from backend.domain.slide_deck import (
     SlideRecord,
     SlideStatus,
 )
-from backend.domain.source import Job, JobStatus, KnowledgeChunk
+from backend.domain.source import JobStatus, KnowledgeChunk
 from backend.infrastructure.slide_deck_files import SlideDeckFileStore
 from backend.infrastructure.repositories.memory_repository import InMemoryKnowledgeRepository
 from backend.infrastructure.repositories.seekdb_repository import SeekDBRepository

--- a/tests/test_slide_deck_export.py
+++ b/tests/test_slide_deck_export.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pptx import Presentation

--- a/tests/test_slide_deck_model_runtime.py
+++ b/tests/test_slide_deck_model_runtime.py
@@ -12,7 +12,6 @@ from backend.core.services.slide_deck_planning_service import SlideDeckPlanningS
 from backend.domain.slide_deck import (
     SlideDeckOutline,
     SlideOutline,
-    SlidePromptPlan,
     SlidePromptPlanSet,
 )
 from backend.infrastructure.image_providers.raw_multimodal_provider import (


### PR DESCRIPTION
## Summary
- add GitHub Actions CI for backend tests/compile, frontend lint/unit/build, and Playwright smoke tests
- add ESLint flat config so the existing frontend lint script is runnable under ESLint 9
- remove the direct vite-node devDependency because the declared version is not available from npm and breaks reproducible npm ci installs
- add CI badges to the English and Chinese READMEs

## Local verification
- `npm ci` in `frontend/`
- `python -m pytest -q` -> 92 passed, 4 warnings
- `python -m compileall -q backend`
- `npm run lint` -> 0 errors, 27 warnings from existing frontend any/hook/Fast Refresh rules
- `npm test -- --run` -> 25 passed
- `npm run build`
- `npm run test:e2e -- interactive-artifacts.spec.ts` -> 1 passed
- `git diff --check`

## Notes
- Real model/PPT generation is intentionally not a blocking CI check because it depends on local secrets and external model availability.
- `npm audit` is intentionally not blocking yet; the current dependency tree reports existing vulnerabilities unrelated to this CI change.