### PR TITLE
feat(studio): polish artifact viewers and podcast persistence

### DIFF
--- a/backend/api/routes/podcast.py
+++ b/backend/api/routes/podcast.py
@@ -96,7 +96,7 @@ async def generate_podcast(
         else:
             raise HTTPException(
                 status_code=400,
-                detail="请提供 source_text 或 document_ids"
+                detail="请提供 source_text、source_ids 或 document_ids"
             )
         
         audio_url = f"/api/podcast/download/{result['audio_filename']}" if result.get("audio_filename") else None
@@ -201,7 +201,7 @@ async def generate_script_only(
                 all_text.append(text)
             source_text = "\n\n---\n\n".join(all_text)
         else:
-            raise HTTPException(status_code=400, detail="请提供文本或文档")
+            raise HTTPException(status_code=400, detail="请提供 source_text、source_ids 或 document_ids")
         
         # 生成脚本
         script = await podcast_service.generate_script_only(

--- a/backend/api/routes/podcast.py
+++ b/backend/api/routes/podcast.py
@@ -3,6 +3,8 @@ Podcast Routes
 
 Handles podcast generation with controllable duration.
 """
+from typing import Callable
+
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import FileResponse
 import os
@@ -14,12 +16,24 @@ from ..schemas.podcast import (
     PodcastScriptResponse
 )
 from ...config import get_settings, Settings
-from ...dependencies import get_vector_store, get_llm_provider, get_audio_speech_provider, get_source_service
+from ...dependencies import (
+    get_audio_speech_provider,
+    get_knowledge_repository,
+    get_llm_provider,
+    get_source_service,
+    get_vector_store,
+)
 from ...core.services.podcast_service import PodcastService
 from ...core.interfaces.vector_store import VectorStoreInterface
 from ...core.services.source_service import SourceService
+from ...core.interfaces.knowledge_repository import KnowledgeRepositoryInterface
+from ...domain.source import Artifact, ArtifactType, JobStatus
 
 router = APIRouter(prefix="/podcast", tags=["Podcast"])
+
+
+def get_podcast_llm_factory() -> Callable:
+    return get_llm_provider
 
 
 @router.post("/generate", response_model=PodcastGenerateResponse)
@@ -28,12 +42,14 @@ async def generate_podcast(
     settings: Settings = Depends(get_settings),
     vector_store: VectorStoreInterface = Depends(get_vector_store),
     source_service: SourceService = Depends(get_source_service),
+    repository: KnowledgeRepositoryInterface = Depends(get_knowledge_repository),
+    llm_factory: Callable = Depends(get_podcast_llm_factory),
     tts = Depends(get_audio_speech_provider),
 ):
     """生成播客（脚本 + 音频）"""
     try:
         # 获取 LLM 提供商
-        llm = get_llm_provider(
+        llm = llm_factory(
             provider=request.llm_provider,
             api_key=request.llm_api_key,
             base_url=request.llm_base_url,
@@ -83,11 +99,60 @@ async def generate_podcast(
                 detail="请提供 source_text 或 document_ids"
             )
         
+        audio_url = f"/api/podcast/download/{result['audio_filename']}" if result.get("audio_filename") else None
+        transcript_url = f"/api/podcast/download/{result['transcript_filename']}"
+        script = result["script"]
+        turns = [{"speaker": turn.speaker, "text": turn.text} for turn in script.dialogues]
+        speakers = list(dict.fromkeys([script.host_name, script.guest_name]))
+        artifact = Artifact(
+            artifact_type=ArtifactType.PODCAST_SCRIPT,
+            title=getattr(script, "title", None) or "Podcast Script",
+            source_ids=request.source_ids or request.document_ids,
+            markdown=result["transcript"],
+            payload={
+                "title": getattr(script, "title", "Podcast Script"),
+                "speakers": speakers,
+                "turns": turns,
+                "estimated_duration_minutes": result["duration_minutes"],
+                "transcript": result["transcript"],
+                "duration_minutes": result["duration_minutes"],
+                "dialogue_count": result["dialogue_count"],
+                "audio_url": audio_url,
+                "audio_status": result.get("audio_status", {}),
+                "audio_filename": result.get("audio_filename"),
+                "transcript_url": transcript_url,
+                "transcript_filename": result.get("transcript_filename"),
+            },
+            file_refs=[
+                {
+                    "format": "markdown",
+                    "mime_type": "text/markdown",
+                    "name": result.get("transcript_filename"),
+                    "url": transcript_url,
+                }
+            ],
+            status=JobStatus.SUCCEEDED,
+        )
+        if audio_url:
+            artifact.file_refs.append(
+                {
+                    "format": "mp3",
+                    "mime_type": "audio/mpeg",
+                    "name": result.get("audio_filename"),
+                    "url": audio_url,
+                }
+            )
+        artifact = await repository.save_artifact(artifact)
+
         return PodcastGenerateResponse(
-            audio_url=f"/api/podcast/download/{result['audio_filename']}" if result.get("audio_filename") else None,
+            artifact_id=artifact.id,
+            title=artifact.title,
+            speakers=speakers,
+            turns=turns,
+            audio_url=audio_url,
             audio_status=result.get("audio_status", {}),
             audio_filename=result.get("audio_filename"),
-            transcript_url=f"/api/podcast/download/{result['transcript_filename']}",
+            transcript_url=transcript_url,
             transcript_filename=result.get("transcript_filename"),
             transcript=result["transcript"],
             duration_minutes=result["duration_minutes"],
@@ -103,10 +168,11 @@ async def generate_script_only(
     request: PodcastScriptRequest,
     vector_store: VectorStoreInterface = Depends(get_vector_store),
     source_service: SourceService = Depends(get_source_service),
+    llm_factory: Callable = Depends(get_podcast_llm_factory),
 ):
     """仅生成播客脚本（不合成音频）"""
     try:
-        llm = get_llm_provider(
+        llm = llm_factory(
             provider=request.llm_provider,
             api_key=request.llm_api_key,
             base_url=request.llm_base_url,

--- a/backend/api/schemas/podcast.py
+++ b/backend/api/schemas/podcast.py
@@ -39,6 +39,10 @@ class PodcastGenerateRequest(BaseModel):
 
 class PodcastGenerateResponse(BaseModel):
     """播客生成响应"""
+    artifact_id: Optional[str] = Field(None, description="持久化的播客 artifact ID")
+    title: str = Field(default="Podcast Script", description="播客标题")
+    speakers: List[str] = Field(default_factory=list, description="播客说话人")
+    turns: List[Dict[str, str]] = Field(default_factory=list, description="结构化对话轮次")
     audio_url: Optional[str] = Field(None, description="音频下载URL")
     audio_status: Dict = Field(default_factory=dict, description="音频生成状态")
     audio_filename: Optional[str] = None

--- a/backend/domain/artifact_schemas.py
+++ b/backend/domain/artifact_schemas.py
@@ -79,6 +79,13 @@ class PodcastScriptArtifactPayload(BaseModel):
     turns: list[dict[str, str]]
     estimated_duration_minutes: float
     transcript: str
+    duration_minutes: float | None = None
+    dialogue_count: int | None = None
+    audio_url: str | None = None
+    audio_status: dict[str, Any] = Field(default_factory=dict)
+    audio_filename: str | None = None
+    transcript_url: str | None = None
+    transcript_filename: str | None = None
 
 
 class PPTOutlineArtifactPayload(BaseModel):

--- a/frontend/e2e/interactive-artifacts.spec.ts
+++ b/frontend/e2e/interactive-artifacts.spec.ts
@@ -47,6 +47,13 @@ const artifactPayloads: Record<string, Record<string, unknown>> = {
         ],
         key_takeaways: ['优先使用 HTTPS', '证书链需要可信']
     },
+    faq: {
+        title: 'HTTPS FAQ',
+        items: [
+            { question: 'HTTPS 解决什么问题？', answer: '它通过 TLS 降低窃听、篡改和身份冒充风险。' },
+            { question: '证书为什么重要？', answer: '证书把服务器身份和公钥绑定起来。' }
+        ]
+    },
     data_table: {
         title: '协议对比表',
         columns: ['协议', '安全性', '用途'],
@@ -205,11 +212,22 @@ test('renders NotebookLM-like interactive Studio artifacts', async ({ page }) =>
     await expect(page.getByRole('heading', { name: '安全属性' })).toBeVisible();
     await expect(page.getByText('证书链需要可信')).toBeVisible();
 
+    await page.getByRole('button', { name: /^FAQ$/ }).click();
+    await page.getByRole('button', { name: '生成', exact: true }).click();
+    await page.getByRole('button', { name: /HTTPS FAQ/ }).click();
+    await expect(page.getByRole('button', { name: 'HTTPS 解决什么问题？' })).toBeVisible();
+    await expect(page.getByText('它通过 TLS 降低窃听、篡改和身份冒充风险。')).not.toBeVisible();
+    await page.getByRole('button', { name: 'HTTPS 解决什么问题？' }).click();
+    await expect(page.getByText('它通过 TLS 降低窃听、篡改和身份冒充风险。')).toBeVisible();
+
     await page.getByRole('button', { name: /表格/ }).click();
     await page.getByRole('button', { name: '生成', exact: true }).click();
     await page.getByRole('button', { name: /协议对比表/ }).click();
     await expect(page.getByRole('columnheader', { name: '协议' })).toBeVisible();
     await expect(page.getByRole('cell', { name: 'TLS 加密' })).toBeVisible();
+    const tableRegion = page.getByRole('region', { name: '横向滚动查看完整表格' });
+    await expect(tableRegion).toBeVisible();
+    await expect.poll(async () => tableRegion.evaluate(element => element.scrollWidth > element.clientWidth)).toBe(true);
 
     let developmentMessage = '';
     page.once('dialog', async dialog => {

--- a/frontend/e2e/interactive-artifacts.spec.ts
+++ b/frontend/e2e/interactive-artifacts.spec.ts
@@ -225,7 +225,7 @@ test('renders NotebookLM-like interactive Studio artifacts', async ({ page }) =>
     await page.getByRole('button', { name: /协议对比表/ }).click();
     await expect(page.getByRole('columnheader', { name: '协议' })).toBeVisible();
     await expect(page.getByRole('cell', { name: 'TLS 加密' })).toBeVisible();
-    const tableRegion = page.getByRole('region', { name: '横向滚动查看完整表格' });
+    const tableRegion = page.getByRole('region', { name: '协议对比表' });
     await expect(tableRegion).toBeVisible();
     await expect.poll(async () => tableRegion.evaluate(element => element.scrollWidth > element.clientWidth)).toBe(true);
 

--- a/frontend/e2e/non-ppt-workflow.spec.ts
+++ b/frontend/e2e/non-ppt-workflow.spec.ts
@@ -14,6 +14,7 @@ const source = {
 test('non-PPT workflow covers source upload, RAG chat, studio artifacts, and podcast script', async ({ page }) => {
     let sources: typeof source[] = [];
     let notes: Array<Record<string, unknown>> = [];
+    let artifacts: Array<Record<string, unknown>> = [];
     let artifactCount = 0;
 
     await page.route('**/api/config', route => route.fulfill({
@@ -74,6 +75,11 @@ test('non-PPT workflow covers source upload, RAG chat, studio artifacts, and pod
             body: JSON.stringify(notes[0])
         });
     });
+    await page.route('**/api/artifacts', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ artifacts, total: artifacts.length })
+    }));
     await page.route('**/api/artifacts/generate', async route => {
         const request = route.request();
         const payload = request.postDataJSON() as { artifact_type: string };
@@ -92,13 +98,62 @@ test('non-PPT workflow covers source upload, RAG chat, studio artifacts, and pod
             })
         });
     });
-    await page.route('**/api/podcast/generate', route => route.fulfill({
+    await page.route('**/api/podcast/generate', route => {
+        const podcastArtifact = {
+            id: 'podcast-artifact-1',
+            artifact_type: 'podcast_script',
+            title: '播客脚本',
+            source_ids: [source.id],
+            created_at: '2026-06-01T00:00:00Z',
+            updated_at: '2026-06-01T00:00:00Z',
+            status: 'succeeded',
+            markdown: '# 播客脚本\n\n1. 开场\n2. 深入讨论',
+            payload: {
+                title: '播客脚本',
+                speakers: ['主持人', '嘉宾'],
+                turns: [
+                    { speaker: '主持人', text: '开场' },
+                    { speaker: '嘉宾', text: '深入讨论' }
+                ],
+                estimated_duration_minutes: 20,
+                duration_minutes: 20,
+                dialogue_count: 2,
+                transcript: '# 播客脚本\n\n1. 开场\n2. 深入讨论',
+                audio_url: '/api/podcast/download/demo.mp3',
+                audio_filename: 'demo.mp3',
+                transcript_url: '/api/podcast/download/demo.md',
+                transcript_filename: 'demo.md',
+                audio_status: { status: 'succeeded' }
+            },
+            file_refs: [
+                { format: 'markdown', mime_type: 'text/markdown', name: 'demo.md', url: '/api/podcast/download/demo.md' },
+                { format: 'mp3', mime_type: 'audio/mpeg', name: 'demo.mp3', url: '/api/podcast/download/demo.mp3' }
+            ]
+        };
+        artifacts = [podcastArtifact, ...artifacts];
+        return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                artifact_id: podcastArtifact.id,
+                title: podcastArtifact.title,
+                speakers: podcastArtifact.payload.speakers,
+                turns: podcastArtifact.payload.turns,
+                transcript: podcastArtifact.payload.transcript,
+                audio_url: podcastArtifact.payload.audio_url,
+                audio_filename: podcastArtifact.payload.audio_filename,
+                transcript_url: podcastArtifact.payload.transcript_url,
+                transcript_filename: podcastArtifact.payload.transcript_filename,
+                audio_status: podcastArtifact.payload.audio_status,
+                duration_minutes: podcastArtifact.payload.duration_minutes,
+                dialogue_count: podcastArtifact.payload.dialogue_count
+            })
+        });
+    });
+    await page.route('**/api/podcast/download/*', route => route.fulfill({
         status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-            transcript: '# 播客脚本\n\n1. 开场\n2. 深入讨论',
-            audio_url: null
-        })
+        contentType: route.request().url().endsWith('.mp3') ? 'audio/mpeg' : 'text/markdown',
+        body: route.request().url().endsWith('.mp3') ? Buffer.from('mp3') : '# 播客脚本'
     }));
 
     await page.goto('/');
@@ -136,7 +191,15 @@ test('non-PPT workflow covers source upload, RAG chat, studio artifacts, and pod
     await page.getByRole('button', { name: '播客' }).click();
     await page.getByRole('button', { name: '20-30' }).click();
     await page.getByRole('button', { name: '生成播客' }).click();
-    await page.getByRole('button', { name: /播客脚本 podcast/ }).click();
+    await page.getByRole('button', { name: /播客脚本/ }).click();
     await expect(page.getByRole('heading', { name: '播客脚本' })).toBeVisible();
     await expect(page.getByRole('listitem').filter({ hasText: '深入讨论' })).toBeVisible();
+    await expect(page.getByRole('link', { name: /MP3/ })).toHaveAttribute('href', /demo\.mp3/);
+    await expect(page.getByRole('link', { name: /Transcript/ })).toHaveAttribute('href', /demo\.md/);
+
+    await page.reload();
+    await page.getByRole('button', { name: /播客脚本/ }).click();
+    await expect(page.getByRole('heading', { name: '播客脚本' })).toBeVisible();
+    await expect(page.getByRole('link', { name: /MP3/ })).toHaveAttribute('href', /demo\.mp3/);
+    await expect(page.getByRole('link', { name: /Transcript/ })).toHaveAttribute('href', /demo\.md/);
 });

--- a/frontend/e2e/non-ppt-workflow.spec.ts
+++ b/frontend/e2e/non-ppt-workflow.spec.ts
@@ -195,11 +195,11 @@ test('non-PPT workflow covers source upload, RAG chat, studio artifacts, and pod
     await expect(page.getByRole('heading', { name: '播客脚本' })).toBeVisible();
     await expect(page.getByRole('listitem').filter({ hasText: '深入讨论' })).toBeVisible();
     await expect(page.getByRole('link', { name: /MP3/ })).toHaveAttribute('href', /demo\.mp3/);
-    await expect(page.getByRole('link', { name: /Transcript/ })).toHaveAttribute('href', /demo\.md/);
+    await expect(page.getByRole('link', { name: /转录文本/ })).toHaveAttribute('href', /demo\.md/);
 
     await page.reload();
     await page.getByRole('button', { name: /播客脚本/ }).click();
     await expect(page.getByRole('heading', { name: '播客脚本' })).toBeVisible();
     await expect(page.getByRole('link', { name: /MP3/ })).toHaveAttribute('href', /demo\.mp3/);
-    await expect(page.getByRole('link', { name: /Transcript/ })).toHaveAttribute('href', /demo\.md/);
+    await expect(page.getByRole('link', { name: /转录文本/ })).toHaveAttribute('href', /demo\.md/);
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -130,9 +130,13 @@ export interface GeneratedContent {
     title: string;
     createdAt: Date;
     audioUrl?: string | null;
+    transcriptUrl?: string | null;
+    audioFilename?: string | null;
+    transcriptFilename?: string | null;
     transcript?: string;
     markdown?: string;
     payload?: Record<string, unknown>;
+    fileRefs?: Array<Record<string, unknown>>;
     downloadJsonUrl?: string;
     downloadMarkdownUrl?: string;
     downloadSvgUrl?: string;
@@ -322,6 +326,12 @@ function App() {
                 createdAt: new Date(artifact.created_at),
                 markdown: artifact.markdown,
                 payload: artifact.payload,
+                fileRefs: artifact.file_refs || [],
+                audioUrl: artifact.payload?.audio_url || null,
+                transcriptUrl: artifact.payload?.transcript_url || null,
+                audioFilename: artifact.payload?.audio_filename || null,
+                transcriptFilename: artifact.payload?.transcript_filename || null,
+                transcript: artifact.payload?.transcript,
                 downloadJsonUrl: `/api/artifacts/${artifact.id}/download?format=json`,
                 downloadMarkdownUrl: `/api/artifacts/${artifact.id}/download?format=markdown`,
                 downloadSvgUrl: artifact.artifact_type === 'infographic' ? `/api/artifacts/${artifact.id}/download?format=svg` : undefined

--- a/frontend/src/components/ArtifactViewer.tsx
+++ b/frontend/src/components/ArtifactViewer.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useId, useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import type { GeneratedContent } from '../App';
+import { useLanguage, type GeneratedContent } from '../App';
 import { MarkdownView } from './MarkdownView';
 
 type AnyRecord = Record<string, any>;
@@ -24,13 +24,12 @@ const FAQViewer: React.FC<{ payload: AnyRecord; markdown?: string }> = ({ payloa
         <div className="faq-viewer">
             {items.map((item: AnyRecord, index: number) => {
                 const expanded = openIndex === index;
-                const question = textValue(item.question);
+                const question = textValue(item?.question);
                 const answerId = `${answerIdPrefix}-faq-answer-${index}`;
                 return (
                     <div key={`${question}-${index}`} className={`faq-item ${expanded ? 'open' : ''}`}>
                         <button
                             className="faq-question"
-                            aria-label={question}
                             aria-expanded={expanded}
                             aria-controls={answerId}
                             onClick={() => setOpenIndex(expanded ? null : index)}
@@ -38,7 +37,7 @@ const FAQViewer: React.FC<{ payload: AnyRecord; markdown?: string }> = ({ payloa
                             <span>{question}</span>
                             <small aria-hidden="true">{index + 1} / {items.length}</small>
                         </button>
-                        {expanded && <p id={answerId} className="faq-answer">{textValue(item.answer)}</p>}
+                        {expanded && <p id={answerId} className="faq-answer">{textValue(item?.answer)}</p>}
                     </div>
                 );
             })}
@@ -235,12 +234,13 @@ const ReportViewer: React.FC<{ payload: AnyRecord; markdown?: string }> = ({ pay
 const DataTableViewer: React.FC<{ payload: AnyRecord; markdown?: string }> = ({ payload, markdown }) => {
     const columns = Array.isArray(payload.columns) ? payload.columns : [];
     const rows = Array.isArray(payload.rows) ? payload.rows : [];
-    const title = textValue(payload.title || 'Data table');
+    const { lang } = useLanguage();
+    const title = textValue(payload.title || (lang === 'zh' ? '数据表' : 'Data table'));
     if (!columns.length) {
         return <MarkdownView content={markdown || ''} className="artifact-preview" />;
     }
     return (
-        <div className="data-table-viewer data-table-scroll" role="region" aria-label="横向滚动查看完整表格" tabIndex={0}>
+        <div className="data-table-viewer data-table-scroll" role="region" aria-label={title} tabIndex={0}>
             <table>
                 <caption>{title}</caption>
                 <thead>

--- a/frontend/src/components/ArtifactViewer.tsx
+++ b/frontend/src/components/ArtifactViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useId, useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { GeneratedContent } from '../App';
 import { MarkdownView } from './MarkdownView';
@@ -10,6 +10,41 @@ interface ArtifactViewerProps {
 }
 
 const textValue = (value: unknown) => value === undefined || value === null ? '' : String(value);
+
+const FAQViewer: React.FC<{ payload: AnyRecord; markdown?: string }> = ({ payload, markdown }) => {
+    const items = Array.isArray(payload.items) ? payload.items : [];
+    const [openIndex, setOpenIndex] = useState<number | null>(null);
+    const answerIdPrefix = useId();
+
+    if (!items.length) {
+        return <MarkdownView content={markdown || ''} className="artifact-preview" />;
+    }
+
+    return (
+        <div className="faq-viewer">
+            {items.map((item: AnyRecord, index: number) => {
+                const expanded = openIndex === index;
+                const question = textValue(item.question);
+                const answerId = `${answerIdPrefix}-faq-answer-${index}`;
+                return (
+                    <div key={`${question}-${index}`} className={`faq-item ${expanded ? 'open' : ''}`}>
+                        <button
+                            className="faq-question"
+                            aria-label={question}
+                            aria-expanded={expanded}
+                            aria-controls={answerId}
+                            onClick={() => setOpenIndex(expanded ? null : index)}
+                        >
+                            <span>{question}</span>
+                            <small aria-hidden="true">{index + 1} / {items.length}</small>
+                        </button>
+                        {expanded && <p id={answerId} className="faq-answer">{textValue(item.answer)}</p>}
+                    </div>
+                );
+            })}
+        </div>
+    );
+};
 
 const FlashcardsViewer: React.FC<{ payload: AnyRecord; markdown?: string }> = ({ payload, markdown }) => {
     const cards = Array.isArray(payload.cards) ? payload.cards : [];
@@ -200,12 +235,14 @@ const ReportViewer: React.FC<{ payload: AnyRecord; markdown?: string }> = ({ pay
 const DataTableViewer: React.FC<{ payload: AnyRecord; markdown?: string }> = ({ payload, markdown }) => {
     const columns = Array.isArray(payload.columns) ? payload.columns : [];
     const rows = Array.isArray(payload.rows) ? payload.rows : [];
+    const title = textValue(payload.title || 'Data table');
     if (!columns.length) {
         return <MarkdownView content={markdown || ''} className="artifact-preview" />;
     }
     return (
-        <div className="data-table-viewer">
+        <div className="data-table-viewer data-table-scroll" role="region" aria-label="横向滚动查看完整表格" tabIndex={0}>
             <table>
+                <caption>{title}</caption>
                 <thead>
                     <tr>
                         {columns.map((column: unknown) => <th key={textValue(column)}>{textValue(column)}</th>)}
@@ -238,6 +275,9 @@ export const ArtifactViewer: React.FC<ArtifactViewerProps> = ({ content }) => {
     }
     if (content.type === 'flashcards' || content.type === 'quiz') {
         return <FlashcardsViewer payload={payload} markdown={content.markdown} />;
+    }
+    if (content.type === 'faq') {
+        return <FAQViewer payload={payload} markdown={content.markdown} />;
     }
     if (content.type === 'mind_map') {
         return <MindMapViewer payload={payload} markdown={content.markdown} />;

--- a/frontend/src/components/StudioPanel.tsx
+++ b/frontend/src/components/StudioPanel.tsx
@@ -274,7 +274,7 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({ sourceIds, config, con
                                     {content.downloadJsonUrl && <a className="secondary-btn" href={content.downloadJsonUrl}><Download size={14} /> JSON</a>}
                                     {content.downloadSvgUrl && <a className="secondary-btn" href={content.downloadSvgUrl}><Download size={14} /> SVG</a>}
                                     {content.audioUrl && <a className="secondary-btn" href={content.audioUrl}><Download size={14} /> MP3</a>}
-                                    {content.transcriptUrl && <a className="secondary-btn" href={content.transcriptUrl}><Download size={14} /> Transcript</a>}
+                                    {content.transcriptUrl && <a className="secondary-btn" href={content.transcriptUrl}><Download size={14} /> {lang === 'zh' ? '转录文本' : 'Transcript'}</a>}
                                 </div>
                             </div>
                         )}

--- a/frontend/src/components/StudioPanel.tsx
+++ b/frontend/src/components/StudioPanel.tsx
@@ -74,13 +74,43 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({ sourceIds, config, con
                 if (!response.ok) throw new Error(await response.text());
                 const data = await response.json();
                 onContentGenerated({
-                    id: crypto.randomUUID(),
-                    type: 'podcast',
-                    title: lang === 'zh' ? '播客脚本' : 'Podcast Script',
+                    id: data.artifact_id || crypto.randomUUID(),
+                    type: 'podcast_script',
+                    title: data.title || (lang === 'zh' ? '播客脚本' : 'Podcast Script'),
                     createdAt: new Date(),
                     audioUrl: data.audio_url,
+                    transcriptUrl: data.transcript_url,
+                    audioFilename: data.audio_filename,
+                    transcriptFilename: data.transcript_filename,
                     transcript: data.transcript,
-                    markdown: data.transcript
+                    payload: {
+                        title: data.title || (lang === 'zh' ? '播客脚本' : 'Podcast Script'),
+                        speakers: data.speakers || [],
+                        turns: data.turns || [],
+                        estimated_duration_minutes: data.duration_minutes,
+                        transcript: data.transcript,
+                        audio_url: data.audio_url,
+                        audio_status: data.audio_status,
+                        duration_minutes: data.duration_minutes,
+                        dialogue_count: data.dialogue_count
+                    },
+                    fileRefs: [
+                        data.transcript_url ? {
+                            format: 'markdown',
+                            mime_type: 'text/markdown',
+                            name: data.transcript_filename,
+                            url: data.transcript_url
+                        } : null,
+                        data.audio_url ? {
+                            format: 'mp3',
+                            mime_type: 'audio/mpeg',
+                            name: data.audio_filename,
+                            url: data.audio_url
+                        } : null
+                    ].filter(Boolean) as Array<Record<string, unknown>>,
+                    markdown: data.transcript,
+                    downloadJsonUrl: data.artifact_id ? `/api/artifacts/${data.artifact_id}/download?format=json` : undefined,
+                    downloadMarkdownUrl: data.artifact_id ? `/api/artifacts/${data.artifact_id}/download?format=markdown` : undefined
                 });
             } else {
                 const response = await fetch('/api/artifacts/generate', {
@@ -239,11 +269,12 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({ sourceIds, config, con
                             <div className="artifact-body">
                                 {content.audioUrl && <audio controls src={content.audioUrl} className="w-full mb-3" />}
                                 <ArtifactViewer content={content} />
-                                <div className="flex gap-2 mt-3">
+                                <div className="flex flex-wrap gap-2 mt-3">
                                     {content.downloadMarkdownUrl && <a className="secondary-btn" href={content.downloadMarkdownUrl}><Download size={14} /> Markdown</a>}
                                     {content.downloadJsonUrl && <a className="secondary-btn" href={content.downloadJsonUrl}><Download size={14} /> JSON</a>}
                                     {content.downloadSvgUrl && <a className="secondary-btn" href={content.downloadSvgUrl}><Download size={14} /> SVG</a>}
                                     {content.audioUrl && <a className="secondary-btn" href={content.audioUrl}><Download size={14} /> MP3</a>}
+                                    {content.transcriptUrl && <a className="secondary-btn" href={content.transcriptUrl}><Download size={14} /> Transcript</a>}
                                 </div>
                             </div>
                         )}

--- a/frontend/src/components/markdown-rendering.test.tsx
+++ b/frontend/src/components/markdown-rendering.test.tsx
@@ -352,7 +352,7 @@ describe('Markdown rendering', () => {
         fireEvent.click(screen.getByRole('button', { name: '播客脚本 podcast_script' }));
 
         expect(screen.getByRole('link', { name: /MP3/ })).toHaveAttribute('href', '/api/podcast/download/demo.mp3');
-        expect(screen.getByRole('link', { name: /Transcript/ })).toHaveAttribute('href', '/api/podcast/download/demo.md');
+        expect(screen.getByRole('link', { name: /转录文本/ })).toHaveAttribute('href', '/api/podcast/download/demo.md');
         expect(screen.getByRole('link', { name: /Markdown/ })).toHaveAttribute('href', '/api/artifacts/podcast-1/download?format=markdown');
     });
 
@@ -380,7 +380,7 @@ describe('Markdown rendering', () => {
             />
         );
 
-        const scrollRegion = screen.getByLabelText('横向滚动查看完整表格');
+        const scrollRegion = screen.getByLabelText('配置对比');
 
         expect(scrollRegion).toHaveAttribute('role', 'region');
         expect(scrollRegion).toHaveAttribute('tabindex', '0');

--- a/frontend/src/components/markdown-rendering.test.tsx
+++ b/frontend/src/components/markdown-rendering.test.tsx
@@ -219,6 +219,41 @@ describe('Markdown rendering', () => {
         expect(screen.getByText('得分 1 / 1')).toBeInTheDocument();
     });
 
+    test('renders FAQ artifacts as collapsible question and answer cards', () => {
+        renderZh(
+            <ArtifactViewer
+                content={{
+                    id: 'faq-1',
+                    type: 'faq',
+                    title: 'FAQ',
+                    createdAt: new Date(),
+                    markdown: '# FAQ\n\n### 理想 L9 的续航是多少？\n\nCLTC 纯电续航 420km。',
+                    payload: {
+                        title: 'FAQ',
+                        items: [
+                            {
+                                question: '理想 L9 的续航是多少？',
+                                answer: 'CLTC 纯电续航 420km。'
+                            },
+                            {
+                                question: '如何重启中控屏？',
+                                answer: '同时按下方向盘滚轮和相关按键。'
+                            }
+                        ]
+                    }
+                }}
+            />
+        );
+
+        expect(screen.getByRole('button', { name: '理想 L9 的续航是多少？' })).toBeInTheDocument();
+        expect(screen.queryByText('CLTC 纯电续航 420km。')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: '理想 L9 的续航是多少？' }));
+
+        expect(screen.getByText('CLTC 纯电续航 420km。')).toBeInTheDocument();
+        expect(screen.getByText('1 / 2')).toBeInTheDocument();
+    });
+
     test('renders infographic SVG through an image URL instead of inline SVG markup', () => {
         const objectUrl = 'blob:infographic';
         const createObjectURL = vi.fn(() => objectUrl);
@@ -274,6 +309,84 @@ describe('Markdown rendering', () => {
         expect(screen.getByRole('heading', { name: 'Rendered Report' })).toBeInTheDocument();
         expect(screen.getByRole('cell', { name: 'HTTP' })).toBeInTheDocument();
         expect(screen.queryByText('## Rendered Report')).not.toBeInTheDocument();
+    });
+
+    test('renders restored podcast artifact audio and transcript download links', () => {
+        const contents: GeneratedContent[] = [
+            {
+                id: 'podcast-1',
+                type: 'podcast_script',
+                title: '播客脚本',
+                createdAt: new Date('2026-06-01T00:00:00Z'),
+                markdown: '# 播客脚本\n\n1. 开场\n2. 深入讨论',
+                transcript: '# 播客脚本\n\n1. 开场\n2. 深入讨论',
+                audioUrl: '/api/podcast/download/demo.mp3',
+                transcriptUrl: '/api/podcast/download/demo.md',
+                audioFilename: 'demo.mp3',
+                transcriptFilename: 'demo.md',
+                fileRefs: [
+                    { format: 'markdown', url: '/api/podcast/download/demo.md' },
+                    { format: 'mp3', url: '/api/podcast/download/demo.mp3' }
+                ],
+                payload: {
+                    title: '播客脚本',
+                    transcript: '# 播客脚本\n\n1. 开场\n2. 深入讨论',
+                    audio_url: '/api/podcast/download/demo.mp3',
+                    transcript_url: '/api/podcast/download/demo.md'
+                },
+                downloadMarkdownUrl: '/api/artifacts/podcast-1/download?format=markdown',
+                downloadJsonUrl: '/api/artifacts/podcast-1/download?format=json'
+            }
+        ];
+
+        renderZh(
+            <StudioPanel
+                sourceIds={['src-1']}
+                config={config}
+                contents={contents}
+                onContentGenerated={vi.fn()}
+                onOpenSlideDeck={vi.fn()}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: '播客脚本 podcast_script' }));
+
+        expect(screen.getByRole('link', { name: /MP3/ })).toHaveAttribute('href', '/api/podcast/download/demo.mp3');
+        expect(screen.getByRole('link', { name: /Transcript/ })).toHaveAttribute('href', '/api/podcast/download/demo.md');
+        expect(screen.getByRole('link', { name: /Markdown/ })).toHaveAttribute('href', '/api/artifacts/podcast-1/download?format=markdown');
+    });
+
+    test('renders data table artifacts in an accessible horizontal scroll region', () => {
+        renderZh(
+            <ArtifactViewer
+                content={{
+                    id: 'table-1',
+                    type: 'data_table',
+                    title: '配置对比',
+                    createdAt: new Date(),
+                    payload: {
+                        title: '配置对比',
+                        columns: ['项目', 'L9 Ultra', 'L9 Livis', '说明'],
+                        rows: [
+                            {
+                                项目: '续航与电池',
+                                'L9 Ultra': '72.7kWh 5C 电池，CLTC 纯电 420km，综合 1650km',
+                                'L9 Livis': '72.7kWh 电池，CLTC 纯电 420km，综合 1650km',
+                                说明: '长文本需要在右侧窄栏中可横向滚动查看'
+                            }
+                        ]
+                    }
+                }}
+            />
+        );
+
+        const scrollRegion = screen.getByLabelText('横向滚动查看完整表格');
+
+        expect(scrollRegion).toHaveAttribute('role', 'region');
+        expect(scrollRegion).toHaveAttribute('tabindex', '0');
+        expect(scrollRegion).toHaveClass('data-table-scroll');
+        expect(within(scrollRegion).getByText('配置对比')).toBeInTheDocument();
+        expect(within(scrollRegion).getByRole('columnheader', { name: 'L9 Livis' })).toBeInTheDocument();
     });
 
     test('renders ordered lists as list items', () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1903,12 +1903,33 @@ body {
     border-radius: 14px;
     border: 1px solid rgba(120, 53, 15, 0.08);
     background: white;
+    max-width: 100%;
+    scrollbar-gutter: stable;
+}
+
+.data-table-scroll {
+    position: relative;
+}
+
+.data-table-scroll:focus {
+    outline: 2px solid rgba(249, 115, 22, 0.45);
+    outline-offset: 2px;
 }
 
 .data-table-viewer table {
-    width: 100%;
-    min-width: 360px;
+    width: max-content;
+    min-width: 520px;
     border-collapse: collapse;
+}
+
+.data-table-viewer caption {
+    caption-side: top;
+    padding: 8px 10px;
+    text-align: left;
+    font-size: 0.78rem;
+    font-weight: 900;
+    color: #7c2d12;
+    background: #fffaf5;
 }
 
 .data-table-viewer th,
@@ -1918,6 +1939,9 @@ body {
     text-align: left;
     vertical-align: top;
     font-size: 0.8rem;
+    min-width: 112px;
+    max-width: 220px;
+    overflow-wrap: anywhere;
 }
 
 .data-table-viewer th {
@@ -1928,6 +1952,48 @@ body {
 
 .data-table-viewer tr:last-child td {
     border-bottom: 0;
+}
+
+.faq-viewer {
+    display: grid;
+    gap: 10px;
+}
+
+.faq-item {
+    border: 1px solid rgba(120, 53, 15, 0.1);
+    border-radius: 14px;
+    background: #fffaf5;
+    overflow: hidden;
+}
+
+.faq-question {
+    width: 100%;
+    border: 0;
+    background: transparent;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 11px 12px;
+    text-align: left;
+    color: #431407;
+    font-weight: 900;
+    cursor: pointer;
+}
+
+.faq-question small {
+    flex: 0 0 auto;
+    color: #f97316;
+    font-size: 0.72rem;
+}
+
+.faq-answer {
+    margin: 0;
+    padding: 0 12px 12px;
+    color: #57534e;
+    font-size: 0.82rem;
+    line-height: 1.55;
+    font-weight: 650;
 }
 
 .placeholder-artifact {

--- a/tests/test_podcast_workflow.py
+++ b/tests/test_podcast_workflow.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
+from backend.api.routes.podcast import get_podcast_llm_factory, router as podcast_router
 from backend.core.services.podcast_service import PodcastService
 from backend.core.workflows.podcast_workflow import PodcastWorkflow
 from backend.domain.podcast import DialogueTurn, DurationRange, PodcastExtension, PodcastScript
+from backend.config import Settings
+from backend.dependencies import get_audio_speech_provider, get_source_service, get_vector_store
+from backend.infrastructure.repositories.memory_repository import InMemoryKnowledgeRepository
 
 
 class PodcastLLM:
@@ -87,6 +93,15 @@ class BrokenAudio:
         raise RuntimeError("tts failed")
 
 
+class FakeSourceService:
+    async def get_source_text(self, source_id: str) -> str:
+        return f"{source_id} source material for podcast."
+
+
+class EmptyVectorStore:
+    pass
+
+
 def test_duration_range_supports_thirty_minutes():
     assert DurationRange.from_minutes(30) == DurationRange.DEEP
     assert DurationRange.DEEP.max_minutes == 30
@@ -138,3 +153,45 @@ async def test_podcast_audio_success_and_failure_preserve_script(tmp_path):
     assert broken_result["audio_status"]["status"] == "failed"
     assert "tts failed" in broken_result["audio_status"]["error"]
     assert broken_result["transcript"].startswith("# Podcast")
+
+
+def test_podcast_api_persists_generated_script_as_artifact(tmp_path):
+    repo = InMemoryKnowledgeRepository()
+    settings = Settings(output_dir=str(tmp_path / "output"))
+
+    app = FastAPI()
+    app.include_router(podcast_router, prefix="/api")
+    app.dependency_overrides[get_vector_store] = lambda: EmptyVectorStore()
+    app.dependency_overrides[get_source_service] = lambda: FakeSourceService()
+    app.dependency_overrides[get_audio_speech_provider] = lambda: FakeAudio()
+    app.dependency_overrides[get_podcast_llm_factory] = lambda: (lambda **kwargs: PodcastLLM())
+
+    # Override by function object used in the route imports.
+    from backend.config import get_settings
+    from backend.dependencies import get_knowledge_repository
+
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.dependency_overrides[get_knowledge_repository] = lambda: repo
+
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/podcast/generate",
+        json={"source_ids": ["src-1"], "duration_range": "3-5"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["artifact_id"]
+    assert payload["title"] == "Podcast"
+    assert payload["speakers"] == ["主持人", "嘉宾"]
+    assert payload["turns"][0] == {"speaker": "主持人", "text": PodcastLLM().turn_text}
+    artifact = repo.artifacts[payload["artifact_id"]]
+    assert artifact.artifact_type.value == "podcast_script"
+    assert artifact.source_ids == ["src-1"]
+    assert artifact.payload["speakers"] == ["主持人", "嘉宾"]
+    assert artifact.payload["turns"][0] == {"speaker": "主持人", "text": PodcastLLM().turn_text}
+    assert artifact.payload["estimated_duration_minutes"] == payload["duration_minutes"]
+    assert artifact.payload["audio_url"] == payload["audio_url"]
+    assert artifact.payload["transcript_url"] == payload["transcript_url"]
+    assert artifact.markdown.startswith("# Podcast")


### PR DESCRIPTION
## Summary

- Add interactive FAQ artifact rendering and improve Data Table horizontal scrolling/accessibility in the Studio panel.
- Persist generated podcast scripts as `podcast_script` artifacts so they survive refresh and remain available through `/api/artifacts`.
- Preserve podcast transcript/audio download metadata across immediate generation and restored artifact views.

## Context

This branch is based on `origin/main` after the Slide Deck/AIPPT integration merge. The merge base is `15641de ci: add project quality checks`, which follows PR #3 `notebooklm-slide-deck-heavy-integration`.

## Validation

- `frontend`: `npm test -- --run`
- `frontend`: `npm run typecheck`
- `frontend`: `npm run build`
- `backend`: `python -m pytest -q`
- `backend`: `python -m ruff check backend tests`
- `backend`: `python -m compileall -q backend`
- `frontend e2e`: `playwright test e2e/interactive-artifacts.spec.ts e2e/non-ppt-workflow.spec.ts`
