### PR TITLE
feat(studio): add artifact detail workspace

### DIFF
--- a/frontend/e2e/interactive-artifacts.spec.ts
+++ b/frontend/e2e/interactive-artifacts.spec.ts
@@ -56,11 +56,33 @@ const artifactPayloads: Record<string, Record<string, unknown>> = {
     },
     data_table: {
         title: '协议对比表',
-        columns: ['协议', '安全性', '用途'],
+        columns: ['协议', '安全性', '用途', '证书配置', '兼容性', '运维关注', '典型配置与注意事项'],
         rows: [
-            { 协议: 'HTTP', 安全性: '明文', 用途: '普通网页' },
-            { 协议: 'HTTPS', 安全性: 'TLS 加密', 用途: '登录和支付' }
+            {
+                协议: 'HTTP',
+                安全性: '明文',
+                用途: '普通网页',
+                证书配置: '不需要证书',
+                兼容性: '所有浏览器支持',
+                运维关注: '避免承载敏感业务',
+                典型配置与注意事项: '只适合公开内容，不应用于登录、支付、私密 API 或需要完整性保护的业务链路。'
+            },
+            {
+                协议: 'HTTPS',
+                安全性: 'TLS 加密',
+                用途: '登录和支付',
+                证书配置: '需要可信证书链',
+                兼容性: '现代浏览器默认优先',
+                运维关注: '续期、TLS 策略、混合内容',
+                典型配置与注意事项: '需要可信证书链、现代 TLS 配置、证书续期监控，并避免混合内容。'
+            }
         ]
+    },
+    video_overview: {
+        title: '视频概览占位',
+        adapter_status: 'placeholder',
+        official_capability: 'Video Overview',
+        message: '功能开发中，后续会接入视频概览生成。'
     },
     infographic: {
         title: 'HTTPS 信息图',
@@ -72,6 +94,12 @@ const artifactPayloads: Record<string, Record<string, unknown>> = {
         footer: 'Grounded in selected sources.',
         svg: '<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540"><rect width="960" height="540" fill="#fff7ed"/><text x="48" y="80">HTTPS 信息图</text><text x="48" y="150">TLS 加密</text></svg>'
     }
+};
+
+const luminance = (cssColor: string) => {
+    const colors = [...cssColor.matchAll(/rgba?\((\d+),\s*(\d+),\s*(\d+)/g)];
+    if (!colors.length) return 255;
+    return Math.max(...colors.map(([, red, green, blue]) => 0.2126 * Number(red) + 0.7152 * Number(green) + 0.0722 * Number(blue)));
 };
 
 test('renders NotebookLM-like interactive Studio artifacts', async ({ page }) => {
@@ -191,6 +219,7 @@ test('renders NotebookLM-like interactive Studio artifacts', async ({ page }) =>
     await expect(page.getByText('HTTPS 在 HTTP 之下使用 TLS 建立安全通道。')).toBeVisible();
     await page.getByRole('button', { name: '重做' }).click();
     await expect(page.getByText('得分 1 / 1')).not.toBeVisible();
+    await page.getByRole('button', { name: /工作室/ }).click();
 
     await page.getByRole('button', { name: /^PPT$/ }).click();
     await expect(page.getByText('Slide Deck 工作区')).toBeVisible();
@@ -200,10 +229,38 @@ test('renders NotebookLM-like interactive Studio artifacts', async ({ page }) =>
     await page.getByRole('button', { name: /思维图谱/ }).click();
     await page.getByRole('button', { name: '生成', exact: true }).click();
     await page.getByRole('button', { name: /HTTPS 思维图谱/ }).click();
+    await expect.poll(async () => page.locator('.panel-right').evaluate(element => Math.round(element.getBoundingClientRect().width))).toBeGreaterThan(500);
     await expect(page.getByRole('button', { name: 'HTTPS 2' })).toBeVisible();
     await expect(page.getByText('TLS 加密')).toBeVisible();
-    await page.getByRole('button', { name: /TLS 加密/ }).click();
     await expect(page.getByText('握手协商')).toBeVisible();
+    await expect(page.locator('.mind-map-viewer button').first()).toHaveAccessibleName('HTTPS 2');
+    await expect(page.locator('.mind-map-viewer')).not.toHaveAttribute('tabindex', '0');
+    const rootBox = await page.getByRole('button', { name: 'HTTPS 2' }).boundingBox();
+    const childBox = await page.getByRole('button', { name: /TLS 加密/ }).boundingBox();
+    expect(rootBox).not.toBeNull();
+    expect(childBox).not.toBeNull();
+    expect(childBox!.x).toBeGreaterThan(rootBox!.x + rootBox!.width);
+    await expect.poll(async () => page.locator('.mind-map-link').count()).toBeGreaterThanOrEqual(2);
+    await expect.poll(async () => page.locator('.mind-map-link').first().evaluate(element => {
+        const style = window.getComputedStyle(element);
+        return {
+            stroke: style.stroke,
+            strokeWidth: Number.parseFloat(style.strokeWidth),
+            opacity: Number.parseFloat(style.opacity || '1')
+        };
+    })).toMatchObject({ strokeWidth: expect.any(Number), opacity: expect.any(Number) });
+    const firstLinkStyle = await page.locator('.mind-map-link').first().evaluate(element => {
+        const style = window.getComputedStyle(element);
+        return {
+            stroke: style.stroke,
+            strokeWidth: Number.parseFloat(style.strokeWidth),
+            opacity: Number.parseFloat(style.opacity || '1')
+        };
+    });
+    expect(firstLinkStyle.stroke).not.toBe('none');
+    expect(firstLinkStyle.strokeWidth).toBeGreaterThanOrEqual(2);
+    expect(firstLinkStyle.opacity).toBeGreaterThanOrEqual(0.8);
+    await page.getByRole('button', { name: /工作室/ }).click();
 
     await page.getByRole('button', { name: /报告/ }).click();
     await page.getByRole('button', { name: '生成', exact: true }).click();
@@ -211,6 +268,7 @@ test('renders NotebookLM-like interactive Studio artifacts', async ({ page }) =>
     await expect(page.getByText('HTTPS 通过 TLS 保护 HTTP 通信。')).toBeVisible();
     await expect(page.getByRole('heading', { name: '安全属性' })).toBeVisible();
     await expect(page.getByText('证书链需要可信')).toBeVisible();
+    await page.getByRole('button', { name: /工作室/ }).click();
 
     await page.getByRole('button', { name: /^FAQ$/ }).click();
     await page.getByRole('button', { name: '生成', exact: true }).click();
@@ -219,6 +277,7 @@ test('renders NotebookLM-like interactive Studio artifacts', async ({ page }) =>
     await expect(page.getByText('它通过 TLS 降低窃听、篡改和身份冒充风险。')).not.toBeVisible();
     await page.getByRole('button', { name: 'HTTPS 解决什么问题？' }).click();
     await expect(page.getByText('它通过 TLS 降低窃听、篡改和身份冒充风险。')).toBeVisible();
+    await page.getByRole('button', { name: /工作室/ }).click();
 
     await page.getByRole('button', { name: /表格/ }).click();
     await page.getByRole('button', { name: '生成', exact: true }).click();
@@ -228,6 +287,14 @@ test('renders NotebookLM-like interactive Studio artifacts', async ({ page }) =>
     const tableRegion = page.getByRole('region', { name: '协议对比表' });
     await expect(tableRegion).toBeVisible();
     await expect.poll(async () => tableRegion.evaluate(element => element.scrollWidth > element.clientWidth)).toBe(true);
+    await tableRegion.evaluate(element => { element.scrollLeft = element.scrollWidth; });
+    await expect.poll(async () => tableRegion.evaluate(element => element.scrollLeft)).toBeGreaterThan(0);
+    const regionBox = await tableRegion.boundingBox();
+    const lastCellBox = await page.getByRole('cell', { name: /需要可信证书链、现代 TLS 配置/ }).boundingBox();
+    expect(regionBox).not.toBeNull();
+    expect(lastCellBox).not.toBeNull();
+    expect(lastCellBox!.x + lastCellBox!.width).toBeLessThanOrEqual(regionBox!.x + regionBox!.width + 1);
+    await page.getByRole('button', { name: /工作室/ }).click();
 
     let developmentMessage = '';
     page.once('dialog', async dialog => {
@@ -244,4 +311,337 @@ test('renders NotebookLM-like interactive Studio artifacts', async ({ page }) =>
     await expect(page.getByText('TLS 加密')).toBeVisible();
     await expect(page.locator('.infographic-frame img')).toBeVisible();
     await expect(page.getByRole('link', { name: /SVG/ })).toBeVisible();
+});
+
+test('keeps artifact detail full-width in narrow stacked layouts', async ({ page }) => {
+    await page.setViewportSize({ width: 760, height: 900 });
+    await page.route('**/api/config', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ models: {} })
+    }));
+    await page.route('**/api/sources', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ sources: [source], total: 1 })
+    }));
+    await page.route('**/api/notes', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ notes: [], total: 0 })
+    }));
+    await page.route('**/api/artifacts', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+            artifacts: [{
+                id: 'artifact-mind_map',
+                artifact_type: 'mind_map',
+                title: artifactPayloads.mind_map.title,
+                created_at: '2026-06-01T00:00:00Z',
+                source_ids: ['src-material'],
+                markdown: '# HTTPS 思维图谱',
+                payload: artifactPayloads.mind_map
+            }],
+            total: 1
+        })
+    }));
+
+    await page.goto('/');
+    await page.getByRole('button', { name: /HTTPS 思维图谱/ }).click();
+
+    await expect.poll(async () => page.locator('.panel-right').evaluate(element => Math.round(element.getBoundingClientRect().width))).toBeGreaterThan(680);
+});
+
+test('preserves usable chat width when artifact details are open on desktop', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 860 });
+    await page.route('**/api/config', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ models: {} })
+    }));
+    await page.route('**/api/sources', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ sources: [source], total: 1 })
+    }));
+    await page.route('**/api/notes', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ notes: [], total: 0 })
+    }));
+    await page.route('**/api/artifacts', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+            artifacts: [{
+                id: 'artifact-mind_map',
+                artifact_type: 'mind_map',
+                title: artifactPayloads.mind_map.title,
+                created_at: '2026-06-01T00:00:00Z',
+                source_ids: ['src-material'],
+                markdown: '# HTTPS 思维图谱',
+                payload: artifactPayloads.mind_map
+            }],
+            total: 1
+        })
+    }));
+
+    await page.goto('/');
+    await page.getByRole('button', { name: /HTTPS 思维图谱/ }).click();
+
+    await expect.poll(async () => page.locator('.panel-center').evaluate(element => Math.round(element.getBoundingClientRect().width))).toBeGreaterThan(300);
+});
+
+test('keeps artifact detail layout usable on phone widths', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 860 });
+    await page.route('**/api/config', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ models: {} })
+    }));
+    await page.route('**/api/sources', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ sources: [source], total: 1 })
+    }));
+    await page.route('**/api/notes', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ notes: [], total: 0 })
+    }));
+    await page.route('**/api/artifacts', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+            artifacts: [{
+                id: 'artifact-mind_map',
+                artifact_type: 'mind_map',
+                title: artifactPayloads.mind_map.title,
+                created_at: '2026-06-01T00:00:00Z',
+                source_ids: ['src-material'],
+                markdown: '# HTTPS 思维图谱',
+                payload: artifactPayloads.mind_map
+            }],
+            total: 1
+        })
+    }));
+
+    await page.goto('/');
+    await page.getByRole('button', { name: /HTTPS 思维图谱/ }).click();
+
+    await expect.poll(async () => page.locator('.panel-center').evaluate(element => Math.round(element.getBoundingClientRect().width))).toBeGreaterThan(300);
+    await expect.poll(async () => page.locator('.panel-right').evaluate(element => Math.round(element.getBoundingClientRect().width))).toBeGreaterThan(300);
+});
+
+test('opens persisted slide deck artifacts in the Slide Deck workspace', async ({ page }) => {
+    let requestedDeckId = '';
+    await page.route('**/api/config', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ models: {} })
+    }));
+    await page.route('**/api/sources', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ sources: [source], total: 1 })
+    }));
+    await page.route('**/api/notes', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ notes: [], total: 0 })
+    }));
+    await page.route('**/api/artifacts', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+            artifacts: [{
+                id: 'artifact-slide-deck',
+                artifact_type: 'slide_deck',
+                title: '恢复的演示文稿',
+                created_at: '2026-06-01T00:00:00Z',
+                source_ids: ['src-material'],
+                markdown: '# 恢复的演示文稿',
+                payload: { deck_id: 'deck-restored-1' }
+            }],
+            total: 1
+        })
+    }));
+    await page.route('**/api/slide-decks/deck-restored-1', route => {
+        requestedDeckId = 'deck-restored-1';
+        return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                id: 'deck-restored-1',
+                title: '恢复的演示文稿',
+                source_ids: ['src-material'],
+                source_snapshot: [{ source_id: 'src-material', title: 'learning.md', excerpt: 'TLS protects HTTP.' }],
+                config_snapshot: { aspect_ratio: '16:9', page_count: 6 },
+                outline: null,
+                prompt_plan: null,
+                slides: [],
+                status: 'draft',
+                stage: 'created',
+                error: null,
+                created_at: '2026-06-01T00:00:00Z',
+                updated_at: '2026-06-01T00:00:00Z'
+            })
+        });
+    });
+
+    await page.goto('/');
+    await page.getByRole('button', { name: /恢复的演示文稿/ }).click();
+
+    await expect(page.getByText('Slide Deck 工作区')).toBeVisible();
+    await expect(page.getByText('恢复的演示文稿')).toBeVisible();
+    await expect(page.getByRole('button', { name: /生成大纲/ })).toBeVisible();
+    expect(requestedDeckId).toBe('deck-restored-1');
+
+    await page.getByRole('button', { name: /返回/ }).click();
+    await expect(page.getByRole('button', { name: /恢复的演示文稿/ })).toBeVisible();
+});
+
+test('keeps Studio artifact details readable and visually integrated in dark mode', async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('notebooklm-theme', 'dark'));
+    await page.route('**/api/config', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ models: {} })
+    }));
+    await page.route('**/api/sources', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ sources: [source], total: 1 })
+    }));
+    await page.route('**/api/notes', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ notes: [], total: 0 })
+    }));
+    await page.route('**/api/artifacts', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+            artifacts: [{
+                id: 'artifact-mind_map',
+                artifact_type: 'mind_map',
+                title: artifactPayloads.mind_map.title,
+                created_at: '2026-06-01T00:00:00Z',
+                source_ids: ['src-material'],
+                markdown: '# HTTPS 思维图谱',
+                payload: artifactPayloads.mind_map
+            }],
+            total: 1
+        })
+    }));
+
+    await page.goto('/');
+    await page.getByRole('button', { name: /HTTPS 思维图谱/ }).click();
+
+    const styles = await page.evaluate(() => {
+        const styleOf = (selector: string) => window.getComputedStyle(document.querySelector(selector)!);
+        return {
+            backColor: styleOf('.studio-back-btn').color,
+            titleColor: styleOf('.artifact-detail-name').color,
+            mindMapBackground: styleOf('.mind-map-viewer').backgroundImage,
+            mindNodeBackground: styleOf('.mind-graph-node').backgroundColor
+        };
+    });
+
+    expect(luminance(styles.backColor)).toBeGreaterThan(170);
+    expect(luminance(styles.titleColor)).toBeGreaterThan(170);
+    expect(luminance(styles.mindMapBackground)).toBeLessThan(120);
+    expect(luminance(styles.mindNodeBackground)).toBeLessThan(160);
+});
+
+test('keeps non-mind-map Studio artifact detail surfaces integrated in dark mode', async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('notebooklm-theme', 'dark'));
+    await page.route('**/api/config', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ models: {} })
+    }));
+    await page.route('**/api/sources', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ sources: [source], total: 1 })
+    }));
+    await page.route('**/api/notes', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ notes: [], total: 0 })
+    }));
+    await page.route('**/api/artifacts', route => route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+            artifacts: ['flashcards', 'report', 'faq', 'data_table', 'infographic', 'video_overview'].map(type => ({
+                id: `artifact-${type}`,
+                artifact_type: type,
+                title: artifactPayloads[type].title,
+                created_at: '2026-06-01T00:00:00Z',
+                source_ids: ['src-material'],
+                markdown: `# ${artifactPayloads[type].title}`,
+                payload: artifactPayloads[type]
+            })),
+            total: 6
+        })
+    }));
+
+    await page.goto('/');
+
+    await page.getByRole('button', { name: /HTTPS 学习卡/ }).click();
+    const flashcardStyles = await page.evaluate(() => {
+        const flashcard = window.getComputedStyle(document.querySelector('.flashcard')!);
+        const quizPanel = window.getComputedStyle(document.querySelector('.quiz-panel')!);
+        return { flashcardBackground: flashcard.backgroundImage, quizBackground: quizPanel.backgroundColor };
+    });
+    expect(luminance(flashcardStyles.flashcardBackground)).toBeLessThan(150);
+    expect(luminance(flashcardStyles.quizBackground)).toBeLessThan(150);
+    await page.getByRole('button', { name: /工作室/ }).click();
+
+    await page.getByRole('button', { name: /HTTPS 报告/ }).click();
+    const reportStyles = await page.evaluate(() => {
+        const summary = window.getComputedStyle(document.querySelector('.report-summary')!);
+        const section = window.getComputedStyle(document.querySelector('.report-section')!);
+        return { summaryBackground: summary.backgroundColor, sectionBackground: section.backgroundColor };
+    });
+    expect(luminance(reportStyles.summaryBackground)).toBeLessThan(150);
+    expect(luminance(reportStyles.sectionBackground)).toBeLessThan(150);
+    await page.getByRole('button', { name: /工作室/ }).click();
+
+    await page.getByRole('button', { name: /HTTPS FAQ/ }).click();
+    const faqStyles = await page.evaluate(() => window.getComputedStyle(document.querySelector('.faq-item')!).backgroundColor);
+    expect(luminance(faqStyles)).toBeLessThan(150);
+    await page.getByRole('button', { name: /工作室/ }).click();
+
+    await page.getByRole('button', { name: /协议对比表/ }).click();
+    const tableStyles = await page.evaluate(() => {
+        const table = window.getComputedStyle(document.querySelector('.data-table-viewer')!);
+        const header = window.getComputedStyle(document.querySelector('.data-table-viewer th')!);
+        return { tableBackground: table.backgroundColor, headerBackground: header.backgroundColor };
+    });
+    expect(luminance(tableStyles.tableBackground)).toBeLessThan(150);
+    expect(luminance(tableStyles.headerBackground)).toBeLessThan(150);
+    await page.getByRole('button', { name: /工作室/ }).click();
+
+    await page.getByRole('button', { name: /HTTPS 信息图/ }).click();
+    const infographicStyles = await page.evaluate(() => {
+        const frame = window.getComputedStyle(document.querySelector('.infographic-frame')!);
+        const section = window.getComputedStyle(document.querySelector('.infographic-section-item')!);
+        return { frameBackground: frame.backgroundColor, sectionBackground: section.backgroundColor };
+    });
+    expect(luminance(infographicStyles.frameBackground)).toBeLessThan(150);
+    expect(luminance(infographicStyles.sectionBackground)).toBeLessThan(150);
+    await page.getByRole('button', { name: /工作室/ }).click();
+
+    await page.getByRole('button', { name: /视频概览占位/ }).click();
+    const placeholderStyles = await page.evaluate(() => {
+        const placeholder = window.getComputedStyle(document.querySelector('.placeholder-artifact')!);
+        const label = window.getComputedStyle(document.querySelector('.placeholder-label')!);
+        return { placeholderBackground: placeholder.backgroundImage, labelBackground: label.backgroundColor };
+    });
+    expect(luminance(placeholderStyles.placeholderBackground)).toBeLessThan(150);
+    expect(luminance(placeholderStyles.labelBackground)).toBeLessThan(150);
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -129,6 +129,7 @@ export interface GeneratedContent {
     type: string;
     title: string;
     createdAt: Date;
+    sourceIds?: string[];
     audioUrl?: string | null;
     transcriptUrl?: string | null;
     audioFilename?: string | null;
@@ -149,6 +150,7 @@ function App() {
     const [generatedContents, setGeneratedContents] = useState<GeneratedContent[]>([]);
     const [notesRefreshKey, setNotesRefreshKey] = useState(0);
     const [showConfig, setShowConfig] = useState(false);
+    const [isStudioDetailMode, setIsStudioDetailMode] = useState(false);
     const [slideDeckWorkspaceId, setSlideDeckWorkspaceId] = useState<string | null | undefined>(() => {
         return localStorage.getItem('notebooklm-active-slide-deck') || undefined;
     });
@@ -324,6 +326,7 @@ function App() {
                 type: artifact.artifact_type,
                 title: artifact.title,
                 createdAt: new Date(artifact.created_at),
+                sourceIds: artifact.source_ids || [],
                 markdown: artifact.markdown,
                 payload: artifact.payload,
                 fileRefs: artifact.file_refs || [],
@@ -398,7 +401,7 @@ function App() {
                         onDeckReady={rememberSlideDeck}
                     />
                 ) : (
-                    <main className="app-main">
+                    <main className={`app-main ${isStudioDetailMode ? 'studio-detail-layout' : ''}`}>
                         <div className="panel panel-left split-panel">
                             <SourcePanel
                                 sources={sources}
@@ -428,6 +431,7 @@ function App() {
                                 contents={generatedContents}
                                 onContentGenerated={handleContentGenerated}
                                 onOpenSlideDeck={openSlideDeck}
+                                onDetailModeChange={setIsStudioDetailMode}
                             />
                         </div>
                     </main>

--- a/frontend/src/components/ArtifactViewer.tsx
+++ b/frontend/src/components/ArtifactViewer.tsx
@@ -4,12 +4,97 @@ import { useLanguage, type GeneratedContent } from '../App';
 import { MarkdownView } from './MarkdownView';
 
 type AnyRecord = Record<string, any>;
+type MindLayoutNode = {
+    id: string;
+    label: string;
+    childCount: number;
+    depth: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+};
+
+type MindLayoutLink = {
+    from: MindLayoutNode;
+    to: MindLayoutNode;
+};
 
 interface ArtifactViewerProps {
     content: GeneratedContent;
 }
 
 const textValue = (value: unknown) => value === undefined || value === null ? '' : String(value);
+
+const mindNodeId = (node: AnyRecord, path: string) => `${path}:${textValue(node.id || node.label || 'node')}`;
+
+const collectExpandableMindIds = (node: AnyRecord, path = 'root'): string[] => {
+    const children = Array.isArray(node.children) ? node.children : [];
+    const id = mindNodeId(node, path);
+    return [
+        ...(children.length ? [id] : []),
+        ...children.flatMap((child: AnyRecord, index: number) => collectExpandableMindIds(child, `${path}-${index}`))
+    ];
+};
+
+const mindNodeWidth = (label: string, depth: number) => {
+    const base = depth === 0 ? 165 : depth === 1 ? 160 : 130;
+    const max = depth === 0 ? 220 : 200;
+    return Math.max(base, Math.min(max, label.length * 7 + 46));
+};
+
+const layoutMindMap = (root: AnyRecord, expandedIds: Set<string>) => {
+    const nodes: MindLayoutNode[] = [];
+    const links: MindLayoutLink[] = [];
+    let nextLeafY = 28;
+
+    const visit = (node: AnyRecord, depth: number, path: string): MindLayoutNode => {
+        const children = Array.isArray(node.children) ? node.children : [];
+        const id = mindNodeId(node, path);
+        const label = textValue(node.label || node.title || 'Untitled');
+        const width = mindNodeWidth(label, depth);
+        const height = 42;
+        const visibleChildren = expandedIds.has(id)
+            ? children.map((child: AnyRecord, index: number) => visit(child, depth + 1, `${path}-${index}`))
+            : [];
+        const y = visibleChildren.length
+            ? visibleChildren.reduce((total, child) => total + child.y, 0) / visibleChildren.length
+            : nextLeafY;
+        if (!visibleChildren.length) {
+            nextLeafY += height + 28;
+        }
+        const layoutNode = {
+            id,
+            label,
+            childCount: children.length,
+            depth,
+            x: 28,
+            y,
+            width,
+            height
+        };
+        nodes.push(layoutNode);
+        visibleChildren.forEach(child => links.push({ from: layoutNode, to: child }));
+        return layoutNode;
+    };
+
+    visit(root, 0, 'root');
+    const columnWidths = nodes.reduce<number[]>((widths, node) => {
+        widths[node.depth] = Math.max(widths[node.depth] || 0, node.width);
+        return widths;
+    }, []);
+    const columnGap = 18;
+    const columnX = columnWidths.reduce<number[]>((positions, width, depth) => {
+        positions[depth] = depth === 0 ? 28 : positions[depth - 1] + columnWidths[depth - 1] + columnGap;
+        return positions;
+    }, []);
+    nodes.forEach(node => {
+        node.x = columnX[node.depth] || 28;
+    });
+    const width = Math.max(620, ...nodes.map(node => node.x + node.width + 48));
+    const height = Math.max(360, ...nodes.map(node => node.y + node.height + 36));
+    return { nodes, links, width, height };
+};
 
 const FAQViewer: React.FC<{ payload: AnyRecord; markdown?: string }> = ({ payload, markdown }) => {
     const items = Array.isArray(payload.items) ? payload.items : [];
@@ -174,32 +259,80 @@ const InfographicViewer: React.FC<{ payload: AnyRecord; markdown?: string }> = (
     );
 };
 
-const MindMapNode: React.FC<{ node: AnyRecord; depth?: number }> = ({ node, depth = 0 }) => {
-    const children = Array.isArray(node.children) ? node.children : [];
-    const [expanded, setExpanded] = useState(depth === 0);
-    return (
-        <div className="mind-node" style={{ ['--depth' as string]: depth }}>
-            <button className="mind-node-button" onClick={() => setExpanded(value => !value)}>
-                <span className="mind-node-dot" />
-                <span>{textValue(node.label)}</span>
-                {children.length > 0 && <span className="mind-node-count">{children.length}</span>}
-            </button>
-            {expanded && children.length > 0 && (
-                <div className="mind-node-children">
-                    {children.map((child: AnyRecord, index: number) => <MindMapNode key={child.id || index} node={child} depth={depth + 1} />)}
-                </div>
-            )}
-        </div>
-    );
-};
-
 const MindMapViewer: React.FC<{ payload: AnyRecord; markdown?: string }> = ({ payload, markdown }) => {
-    if (!payload.root) {
+    const root = payload.root;
+    const expandableIds = useMemo(() => root ? collectExpandableMindIds(root) : [], [root]);
+    const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set(expandableIds));
+    useEffect(() => {
+        setExpandedIds(new Set(expandableIds));
+    }, [expandableIds]);
+    const layout = useMemo(() => root ? layoutMindMap(root, expandedIds) : null, [root, expandedIds]);
+    const toggleNode = (node: MindLayoutNode) => {
+        if (!node.childCount) return;
+        setExpandedIds(current => {
+            const next = new Set(current);
+            if (next.has(node.id)) next.delete(node.id);
+            else next.add(node.id);
+            return next;
+        });
+    };
+    if (!root || !layout) {
         return <MarkdownView content={markdown || ''} className="artifact-preview" />;
     }
+    const renderNodes = [...layout.nodes].sort((left, right) => left.depth - right.depth || left.y - right.y || left.x - right.x);
+
     return (
-        <div className="mind-map-viewer">
-            <MindMapNode node={payload.root} />
+        <div className="mind-map-viewer" role="region" aria-label={textValue(payload.title || 'Mind map')}>
+            <div className="mind-map-canvas" style={{ width: layout.width, height: layout.height }}>
+                <svg className="mind-map-links" width={layout.width} height={layout.height} aria-hidden="true">
+                    {layout.links.map(link => {
+                        const x1 = link.from.x + link.from.width;
+                        const y1 = link.from.y + link.from.height / 2;
+                        const x2 = link.to.x;
+                        const y2 = link.to.y + link.to.height / 2;
+                        const curve = Math.max(48, (x2 - x1) * 0.55);
+                        return (
+                            <path
+                                key={`${link.from.id}-${link.to.id}`}
+                                className={`mind-map-link depth-${Math.min(link.from.depth, 4)}`}
+                                d={`M ${x1} ${y1} C ${x1 + curve} ${y1}, ${x2 - curve} ${y2}, ${x2} ${y2}`}
+                            />
+                        );
+                    })}
+                </svg>
+                {renderNodes.map(node => {
+                    const nodeClassName = `mind-graph-node depth-${Math.min(node.depth, 4)} ${node.childCount ? 'has-children' : 'leaf'}`;
+                    const nodeStyle = { left: node.x, top: node.y, width: node.width, minHeight: node.height };
+                    const nodeContent = (
+                        <>
+                            <span className="mind-graph-label">{node.label}</span>
+                            {node.childCount > 0 && (
+                                <span className="mind-graph-count">{expandedIds.has(node.id) ? '−' : '+'}{node.childCount}</span>
+                            )}
+                        </>
+                    );
+                    if (!node.childCount) {
+                        return (
+                            <div key={node.id} className={nodeClassName} style={nodeStyle}>
+                                {nodeContent}
+                            </div>
+                        );
+                    }
+                    return (
+                        <button
+                            key={node.id}
+                            type="button"
+                            className={nodeClassName}
+                            style={nodeStyle}
+                            onClick={() => toggleNode(node)}
+                            aria-label={`${node.label} ${node.childCount}`}
+                            aria-expanded={expandedIds.has(node.id)}
+                        >
+                            {nodeContent}
+                        </button>
+                    );
+                })}
+            </div>
         </div>
     );
 };

--- a/frontend/src/components/StudioPanel.tsx
+++ b/frontend/src/components/StudioPanel.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { BarChart3, ChevronDown, ChevronUp, Download, FileQuestion, Film, Headphones, Image, Loader2, Network, Presentation, Rows3, SquareStack } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ArrowLeft, BarChart3, Download, FileQuestion, Film, Headphones, Image, Loader2, MoreVertical, Network, Presentation, Rows3, SquareStack } from 'lucide-react';
 import type { ApiConfig, GeneratedContent } from '../App';
 import { translations, useLanguage } from '../App';
 import { ArtifactViewer } from './ArtifactViewer';
@@ -10,6 +10,7 @@ interface StudioPanelProps {
     contents: GeneratedContent[];
     onContentGenerated: (content: GeneratedContent) => void;
     onOpenSlideDeck: (deckId: string | null) => void;
+    onDetailModeChange?: (active: boolean) => void;
 }
 
 const TOOLS = [
@@ -24,7 +25,27 @@ const TOOLS = [
     { id: 'infographic', icon: Image, labelKey: 'infographic', styleClass: 'tool-infographic' }
 ];
 
-export const StudioPanel: React.FC<StudioPanelProps> = ({ sourceIds, config, contents, onContentGenerated, onOpenSlideDeck }) => {
+const TYPE_LABELS: Record<string, { zh: string; en: string }> = {
+    podcast_script: { zh: '播客', en: 'Podcast' },
+    mind_map: { zh: '思维导图', en: 'Mind Map' },
+    faq: { zh: 'FAQ', en: 'FAQ' },
+    flashcards: { zh: '卡片', en: 'Flashcards' },
+    quiz: { zh: '测验', en: 'Quiz' },
+    report: { zh: '报告', en: 'Report' },
+    study_guide: { zh: '学习指南', en: 'Study Guide' },
+    data_table: { zh: '数据表', en: 'Data Table' },
+    infographic: { zh: '信息图', en: 'Infographic' },
+    video_overview: { zh: '视频概览', en: 'Video Overview' },
+    ppt_outline: { zh: 'PPT', en: 'PPT' },
+    slide_deck: { zh: 'PPT', en: 'Slide Deck' }
+};
+
+const toolForType = (type: string) => {
+    if (type === 'podcast_script') return TOOLS[0];
+    return TOOLS.find(tool => tool.id === type) || TOOLS.find(tool => tool.id === 'report')!;
+};
+
+export const StudioPanel: React.FC<StudioPanelProps> = ({ sourceIds, config, contents, onContentGenerated, onOpenSlideDeck, onDetailModeChange }) => {
     const { lang } = useLanguage();
     const t = translations[lang];
     const [activeTool, setActiveTool] = useState<string>('podcast');
@@ -36,7 +57,15 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({ sourceIds, config, con
     const [detail, setDetail] = useState('standard');
     const [customPrompt, setCustomPrompt] = useState('');
     const [isGenerating, setIsGenerating] = useState(false);
-    const [expandedId, setExpandedId] = useState<string | null>(null);
+    const [selectedContentId, setSelectedContentId] = useState<string | null>(null);
+    const selectedContent = useMemo(
+        () => contents.find(content => content.id === selectedContentId) || null,
+        [contents, selectedContentId]
+    );
+    useEffect(() => {
+        onDetailModeChange?.(Boolean(selectedContent));
+        return () => onDetailModeChange?.(false);
+    }, [onDetailModeChange, selectedContent]);
 
     const selectTool = (toolId: string) => {
         if (toolId === 'ppt_outline') {
@@ -78,6 +107,7 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({ sourceIds, config, con
                     type: 'podcast_script',
                     title: data.title || (lang === 'zh' ? '播客脚本' : 'Podcast Script'),
                     createdAt: new Date(),
+                    sourceIds,
                     audioUrl: data.audio_url,
                     transcriptUrl: data.transcript_url,
                     audioFilename: data.audio_filename,
@@ -129,6 +159,7 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({ sourceIds, config, con
                     type: artifact.artifact_type,
                     title: artifact.title,
                     createdAt: new Date(artifact.created_at),
+                    sourceIds: artifact.source_ids || sourceIds,
                     markdown: artifact.markdown,
                     payload: artifact.payload,
                     downloadJsonUrl: `/api/artifacts/${artifact.id}/download?format=json`,
@@ -161,6 +192,49 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({ sourceIds, config, con
             customPrompt.trim() ? `custom_prompt: ${customPrompt.trim()}` : ''
         ].filter(Boolean).join('\n');
     };
+
+    const contentSourceCount = (content: GeneratedContent) => content.sourceIds === undefined ? sourceIds.length : content.sourceIds.length;
+    const typeLabel = (type: string) => TYPE_LABELS[type]?.[lang] || type;
+    const renderDownloads = (content: GeneratedContent) => (
+        <div className="artifact-downloads">
+            {content.downloadMarkdownUrl && <a className="secondary-btn" href={content.downloadMarkdownUrl}><Download size={14} /> Markdown</a>}
+            {content.downloadJsonUrl && <a className="secondary-btn" href={content.downloadJsonUrl}><Download size={14} /> JSON</a>}
+            {content.downloadSvgUrl && <a className="secondary-btn" href={content.downloadSvgUrl}><Download size={14} /> SVG</a>}
+            {content.audioUrl && <a className="secondary-btn" href={content.audioUrl}><Download size={14} /> MP3</a>}
+            {content.transcriptUrl && <a className="secondary-btn" href={content.transcriptUrl}><Download size={14} /> {lang === 'zh' ? '转录文本' : 'Transcript'}</a>}
+        </div>
+    );
+
+    if (selectedContent) {
+        return (
+            <>
+                <div className="panel-header studio-detail-header">
+                    <button className="studio-back-btn" onClick={() => setSelectedContentId(null)}>
+                        <ArrowLeft size={17} />
+                        {t.studio}
+                    </button>
+                    <span className="studio-detail-crumb">{typeLabel(selectedContent.type)}</span>
+                </div>
+                <div className="panel-body studio-detail-pane">
+                    <div className="artifact-detail-title">
+                        <div>
+                            <p>{typeLabel(selectedContent.type)}</p>
+                            <div className="artifact-detail-name">{selectedContent.title}</div>
+                            <span>
+                                {contentSourceCount(selectedContent)} {lang === 'zh' ? '个来源' : contentSourceCount(selectedContent) === 1 ? 'source' : 'sources'}
+                            </span>
+                        </div>
+                        <span className="artifact-detail-more" aria-hidden="true">
+                            <MoreVertical size={18} />
+                        </span>
+                    </div>
+                    {selectedContent.audioUrl && <audio controls src={selectedContent.audioUrl} className="w-full mb-3" />}
+                    <ArtifactViewer content={selectedContent} />
+                    {renderDownloads(selectedContent)}
+                </div>
+            </>
+        );
+    }
 
     return (
         <>
@@ -247,39 +321,34 @@ export const StudioPanel: React.FC<StudioPanelProps> = ({ sourceIds, config, con
                         <p className="text-sm text-gray-400">{t.noContent}</p>
                     </div>
                 )}
-                {contents.map(content => (
-                    <div key={content.id} className="artifact-card">
-                        <button
-                            className="artifact-head"
-                            onClick={() => {
-                                if (content.type === 'slide_deck' && typeof content.payload?.deck_id === 'string') {
-                                    onOpenSlideDeck(content.payload.deck_id);
-                                    return;
-                                }
-                                setExpandedId(expandedId === content.id ? null : content.id);
-                            }}
-                        >
-                            <div>
-                                <div className="text-sm font-semibold text-gray-800">{content.title}</div>
-                                <div className="text-[11px] text-gray-500">{content.type}</div>
-                            </div>
-                            {expandedId === content.id ? <ChevronUp size={17} /> : <ChevronDown size={17} />}
-                        </button>
-                        {expandedId === content.id && (
-                            <div className="artifact-body">
-                                {content.audioUrl && <audio controls src={content.audioUrl} className="w-full mb-3" />}
-                                <ArtifactViewer content={content} />
-                                <div className="flex flex-wrap gap-2 mt-3">
-                                    {content.downloadMarkdownUrl && <a className="secondary-btn" href={content.downloadMarkdownUrl}><Download size={14} /> Markdown</a>}
-                                    {content.downloadJsonUrl && <a className="secondary-btn" href={content.downloadJsonUrl}><Download size={14} /> JSON</a>}
-                                    {content.downloadSvgUrl && <a className="secondary-btn" href={content.downloadSvgUrl}><Download size={14} /> SVG</a>}
-                                    {content.audioUrl && <a className="secondary-btn" href={content.audioUrl}><Download size={14} /> MP3</a>}
-                                    {content.transcriptUrl && <a className="secondary-btn" href={content.transcriptUrl}><Download size={14} /> {lang === 'zh' ? '转录文本' : 'Transcript'}</a>}
-                                </div>
-                            </div>
-                        )}
-                    </div>
-                ))}
+                <div className="artifact-list">
+                    {contents.map(content => {
+                        const tool = toolForType(content.type);
+                        const Icon = tool.icon;
+                        return (
+                            <button
+                                key={content.id}
+                                className="artifact-list-item"
+                                onClick={() => {
+                                    if (content.type === 'slide_deck' && typeof content.payload?.deck_id === 'string') {
+                                        onOpenSlideDeck(content.payload.deck_id);
+                                        return;
+                                    }
+                                    setSelectedContentId(content.id);
+                                }}
+                            >
+                                <span className={`artifact-list-icon ${tool.styleClass}`}><Icon size={22} /></span>
+                                <span className="artifact-list-text">
+                                    <strong>{content.title}</strong>
+                                    <small>
+                                        {contentSourceCount(content)} {lang === 'zh' ? '个来源' : contentSourceCount(content) === 1 ? 'source' : 'sources'} · {typeLabel(content.type)}
+                                    </small>
+                                </span>
+                                <MoreVertical size={18} className="artifact-list-more" />
+                            </button>
+                        );
+                    })}
+                </div>
             </div>
         </>
     );

--- a/frontend/src/components/markdown-rendering.test.tsx
+++ b/frontend/src/components/markdown-rendering.test.tsx
@@ -288,6 +288,7 @@ describe('Markdown rendering', () => {
                 type: 'report',
                 title: 'Generated Artifact',
                 createdAt: new Date('2026-06-01T00:00:00Z'),
+                sourceIds: [],
                 markdown: '## Rendered Report\n\n| 项目 | 说明 |\n| --- | --- |\n| HTTP | 明文传输 |',
                 downloadMarkdownUrl: '/download.md',
                 downloadJsonUrl: '/download.json'
@@ -304,11 +305,20 @@ describe('Markdown rendering', () => {
             />
         );
 
-        fireEvent.click(screen.getByRole('button', { name: 'Generated Artifact report' }));
+        expect(screen.getByRole('button', { name: /Generated Artifact/ })).toHaveTextContent('0 个来源 · 报告');
+        expect(screen.queryByRole('heading', { name: 'Rendered Report' })).not.toBeInTheDocument();
 
+        fireEvent.click(screen.getByRole('button', { name: /Generated Artifact/ }));
+
+        expect(screen.queryByRole('button', { name: '更多' })).not.toBeInTheDocument();
         expect(screen.getByRole('heading', { name: 'Rendered Report' })).toBeInTheDocument();
         expect(screen.getByRole('cell', { name: 'HTTP' })).toBeInTheDocument();
         expect(screen.queryByText('## Rendered Report')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: '工作室' }));
+
+        expect(screen.getByRole('button', { name: /Generated Artifact/ })).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Rendered Report' })).not.toBeInTheDocument();
     });
 
     test('renders restored podcast artifact audio and transcript download links', () => {
@@ -349,11 +359,142 @@ describe('Markdown rendering', () => {
             />
         );
 
-        fireEvent.click(screen.getByRole('button', { name: '播客脚本 podcast_script' }));
+        fireEvent.click(screen.getByRole('button', { name: /播客脚本/ }));
 
         expect(screen.getByRole('link', { name: /MP3/ })).toHaveAttribute('href', '/api/podcast/download/demo.mp3');
         expect(screen.getByRole('link', { name: /转录文本/ })).toHaveAttribute('href', '/api/podcast/download/demo.md');
         expect(screen.getByRole('link', { name: /Markdown/ })).toHaveAttribute('href', '/api/artifacts/podcast-1/download?format=markdown');
+    });
+
+    test('opens restored slide deck artifacts from the generated content list', () => {
+        const onOpenSlideDeck = vi.fn();
+        const contents: GeneratedContent[] = [
+            {
+                id: 'deck-artifact-1',
+                type: 'slide_deck',
+                title: '产品发布演示',
+                createdAt: new Date('2026-06-01T00:00:00Z'),
+                markdown: '# 产品发布演示',
+                payload: { deck_id: 'deck-restored-1' }
+            }
+        ];
+
+        renderZh(
+            <StudioPanel
+                sourceIds={['src-1']}
+                config={config}
+                contents={contents}
+                onContentGenerated={vi.fn()}
+                onOpenSlideDeck={onOpenSlideDeck}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /产品发布演示/ }));
+
+        expect(onOpenSlideDeck).toHaveBeenCalledWith('deck-restored-1');
+        expect(screen.queryByRole('heading', { name: '产品发布演示' })).not.toBeInTheDocument();
+    });
+
+    test('renders mind maps as a connected graph with collapsible multi-level nodes', () => {
+        const { container } = renderZh(
+            <ArtifactViewer
+                content={{
+                    id: 'mind-1',
+                    type: 'mind_map',
+                    title: 'HTTPS 思维图谱',
+                    createdAt: new Date(),
+                    payload: {
+                        title: 'HTTPS 思维图谱',
+                        root: {
+                            id: 'root',
+                            label: 'HTTPS',
+                            children: [
+                                {
+                                    id: 'tls',
+                                    label: 'TLS 加密',
+                                    children: [{ id: 'handshake', label: '握手协商', children: [] }]
+                                },
+                                { id: 'cert', label: '证书验证', children: [] }
+                            ]
+                        }
+                    }
+                }}
+            />
+        );
+
+        expect(screen.getByRole('region', { name: 'HTTPS 思维图谱' })).toBeInTheDocument();
+        expect(container.querySelectorAll('.mind-map-link')).toHaveLength(3);
+        expect(screen.getByRole('button', { name: /HTTPS/ })).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByText('握手协商')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /TLS 加密/ }));
+
+        expect(screen.queryByText('握手协商')).not.toBeInTheDocument();
+    });
+
+    test('does not expose leaf mind map nodes as no-op buttons', () => {
+        renderZh(
+            <ArtifactViewer
+                content={{
+                    id: 'mind-leaf',
+                    type: 'mind_map',
+                    title: '叶子节点图谱',
+                    createdAt: new Date(),
+                    payload: {
+                        title: '叶子节点图谱',
+                        root: {
+                            id: 'root',
+                            label: 'Root',
+                            children: [{ id: 'leaf', label: 'Leaf concept', children: [] }]
+                        }
+                    }
+                }}
+            />
+        );
+
+        expect(screen.getByText('Leaf concept')).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Leaf concept' })).not.toBeInTheDocument();
+    });
+
+    test('keeps mind map expansion independent when model returns duplicate node ids', () => {
+        renderZh(
+            <ArtifactViewer
+                content={{
+                    id: 'mind-duplicate',
+                    type: 'mind_map',
+                    title: '重复 ID 图谱',
+                    createdAt: new Date(),
+                    payload: {
+                        title: '重复 ID 图谱',
+                        root: {
+                            id: 'root',
+                            label: 'Root',
+                            children: [
+                                {
+                                    id: 'dup',
+                                    label: 'Shared',
+                                    children: [{ id: 'leaf', label: 'First leaf', children: [] }]
+                                },
+                                {
+                                    id: 'dup',
+                                    label: 'Shared',
+                                    children: [{ id: 'leaf', label: 'Second leaf', children: [] }]
+                                }
+                            ]
+                        }
+                    }
+                }}
+            />
+        );
+
+        const duplicateNodes = screen.getAllByRole('button', { name: 'Shared 1' });
+        expect(screen.getByText('First leaf')).toBeInTheDocument();
+        expect(screen.getByText('Second leaf')).toBeInTheDocument();
+
+        fireEvent.click(duplicateNodes[0]);
+
+        expect(screen.queryByText('First leaf')).not.toBeInTheDocument();
+        expect(screen.getByText('Second leaf')).toBeInTheDocument();
     });
 
     test('renders data table artifacts in an accessible horizontal scroll region', () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -196,26 +196,128 @@
     border-color: #0f766e;
 }
 
-.artifact-card {
-    background: white;
-    border: 1px solid #e5e7eb;
-    border-radius: 8px;
-    margin-bottom: 10px;
+.artifact-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 
-.artifact-head {
+.artifact-list-item {
     width: 100%;
-    display: flex;
+    min-height: 74px;
+    display: grid;
+    grid-template-columns: 42px minmax(0, 1fr) 22px;
     align-items: center;
-    justify-content: space-between;
-    gap: 10px;
+    gap: 12px;
     padding: 12px;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.86);
+    border: 1px solid rgba(120, 53, 15, 0.08);
+    box-shadow: 0 8px 20px rgba(120, 53, 15, 0.05);
     text-align: left;
 }
 
-.artifact-body {
-    border-top: 1px solid #e5e7eb;
-    padding: 12px;
+.artifact-list-item:hover {
+    border-color: rgba(249, 115, 22, 0.32);
+    transform: translateY(-1px);
+}
+
+.artifact-list-icon {
+    width: 42px;
+    height: 42px;
+    display: inline-grid;
+    place-items: center;
+    border-radius: 12px;
+}
+
+.artifact-list-text {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.artifact-list-text strong {
+    color: #1f2937;
+    font-size: 0.9rem;
+    line-height: 1.25;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.artifact-list-text small,
+.artifact-list-more {
+    color: #78716c;
+}
+
+.studio-detail-header {
+    gap: 10px;
+}
+
+.studio-back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    border: 0;
+    background: transparent;
+    color: #1f2937;
+    font-weight: 900;
+    font-size: 0.95rem;
+}
+
+.studio-detail-crumb {
+    min-width: 0;
+    color: #78716c;
+    font-size: 0.78rem;
+    font-weight: 800;
+}
+
+.studio-detail-pane {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.artifact-detail-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.artifact-detail-title p {
+    margin: 0 0 4px;
+    color: #ea580c;
+    font-size: 0.72rem;
+    font-weight: 900;
+}
+
+.artifact-detail-name {
+    margin: 0;
+    color: #111827;
+    font-size: 1.3rem;
+    line-height: 1.2;
+    font-weight: 900;
+}
+
+.artifact-detail-title span {
+    display: inline-block;
+    margin-top: 7px;
+    color: #78716c;
+    font-size: 0.78rem;
+    font-weight: 800;
+}
+
+.artifact-downloads {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.artifact-detail-more {
+    color: #78716c;
+    line-height: 0;
 }
 
 .artifact-preview {
@@ -770,7 +872,6 @@ body {
 .app-container.dark .source-row,
 .app-container.dark .tool-btn,
 .app-container.dark .duration-btn,
-.app-container.dark .artifact-card,
 .app-container.dark .content-card,
 .app-container.dark .file-card,
 .app-container.dark .chat-bubble-ai,
@@ -794,7 +895,6 @@ body {
     color: #7dd3fc;
 }
 
-.app-container.dark .artifact-body,
 .app-container.dark .artifact-preview {
     border-color: #2f3d42;
 }
@@ -1223,6 +1323,45 @@ body {
     width: 340px;
 }
 
+.app-main.studio-detail-layout .panel-center {
+    flex: 1 1 320px;
+    min-width: 320px;
+}
+
+.app-main.studio-detail-layout .panel-right {
+    width: min(780px, calc(100vw - 688px));
+}
+
+@media (max-width: 1200px) {
+    .app-main.studio-detail-layout {
+        height: auto;
+        min-height: calc(100vh - 80px);
+        overflow: visible;
+        display: grid;
+        grid-template-columns: 280px minmax(0, 1fr);
+    }
+
+    .app-main.studio-detail-layout .panel-center {
+        flex: initial;
+        min-width: 0;
+    }
+
+    .app-main.studio-detail-layout .panel-right {
+        width: auto;
+        grid-column: 1 / -1;
+    }
+}
+
+@media (max-width: 760px) {
+    .app-main.studio-detail-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .app-main.studio-detail-layout .panel-right {
+        grid-column: 1;
+    }
+}
+
 .panel-header h2 {
     color: #1f2937;
 }
@@ -1476,13 +1615,6 @@ body {
     box-shadow: 0 8px 18px rgba(249, 115, 22, 0.18);
 }
 
-.artifact-card {
-    border-radius: 16px;
-    border-color: rgba(120, 53, 15, 0.06);
-    box-shadow: 0 6px 18px rgba(120, 53, 15, 0.05);
-}
-
-.artifact-body,
 .artifact-preview,
 .markdown-table-wrap {
     border-color: rgba(120, 53, 15, 0.08);
@@ -1682,53 +1814,195 @@ body {
 
 .mind-map-viewer {
     border-radius: 16px;
-    padding: 12px;
-    background: linear-gradient(180deg, rgba(255, 251, 235, 0.72), rgba(255, 255, 255, 0.76));
-    border: 1px solid rgba(245, 158, 11, 0.16);
+    padding: 14px;
+    min-height: 360px;
+    max-height: calc(100vh - 260px);
+    overflow: auto;
+    background: linear-gradient(180deg, rgba(255, 251, 235, 0.74), rgba(255, 255, 255, 0.9));
+    border: 1px solid rgba(245, 158, 11, 0.24);
 }
 
-.mind-node {
-    margin-left: calc(var(--depth, 0) * 14px);
+.mind-map-canvas {
+    position: relative;
+    min-width: 100%;
 }
 
-.mind-node-button {
-    display: inline-flex;
+.mind-map-links {
+    position: absolute;
+    inset: 0;
+    overflow: visible;
+    pointer-events: none;
+}
+
+.mind-map-link {
+    fill: none;
+    stroke: #2563eb;
+    stroke-width: 2.6px;
+    stroke-linecap: round;
+    opacity: 0.95;
+}
+
+.mind-map-link.depth-1 {
+    stroke: #0284c7;
+}
+
+.mind-map-link.depth-2 {
+    stroke: #0f766e;
+}
+
+.mind-map-link.depth-3,
+.mind-map-link.depth-4 {
+    stroke: #15803d;
+}
+
+.mind-graph-node {
+    position: absolute;
+    z-index: 2;
+    display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 8px;
-    min-height: 32px;
-    border-radius: 999px;
-    padding: 5px 10px;
-    margin: 4px 0;
-    background: white;
-    border: 1px solid rgba(120, 53, 15, 0.1);
-    color: #334155;
-    font-size: 0.82rem;
-    font-weight: 800;
+    min-width: 0;
+    border: 1px solid #bfdbfe;
+    border-radius: 10px;
+    padding: 9px 11px;
+    background: #dbeafe;
+    color: #111827;
+    font-size: 0.78rem;
+    font-weight: 850;
+    line-height: 1.2;
+    text-align: left;
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
 }
 
-.mind-node-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 999px;
-    background: #f59e0b;
-    box-shadow: 0 0 0 4px #ffedd5;
+.mind-graph-node.depth-0 {
+    background: #c7d2fe;
+    border-color: #a5b4fc;
 }
 
-.mind-node-count {
-    min-width: 18px;
-    height: 18px;
+.mind-graph-node.depth-1 {
+    background: #bfdbfe;
+    border-color: #93c5fd;
+}
+
+.mind-graph-node.depth-2 {
+    background: #99f6e4;
+    border-color: #5eead4;
+}
+
+.mind-graph-node.depth-3,
+.mind-graph-node.depth-4 {
+    background: #bbf7d0;
+    border-color: #86efac;
+}
+
+.mind-graph-node.has-children {
+    cursor: pointer;
+}
+
+.mind-graph-node:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+}
+
+.mind-graph-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.mind-graph-count {
+    flex: 0 0 auto;
+    min-width: 22px;
+    height: 22px;
     display: inline-grid;
     place-items: center;
     border-radius: 999px;
-    background: #fff7ed;
-    color: #c2410c;
-    font-size: 0.68rem;
+    background: rgba(255, 255, 255, 0.74);
+    color: #1d4ed8;
+    font-size: 0.7rem;
+    font-weight: 900;
 }
 
-.mind-node-children {
-    border-left: 1px dashed rgba(245, 158, 11, 0.38);
-    margin-left: 9px;
-    padding-left: 8px;
+.app-container.dark .artifact-list-item {
+    background: rgba(30, 41, 36, 0.9);
+    border-color: rgba(251, 191, 36, 0.16);
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.18);
+}
+
+.app-container.dark .artifact-list-text strong,
+.app-container.dark .artifact-detail-name,
+.app-container.dark .studio-back-btn {
+    color: #f8fafc;
+}
+
+.app-container.dark .artifact-list-text small,
+.app-container.dark .artifact-list-more,
+.app-container.dark .artifact-detail-title span,
+.app-container.dark .studio-detail-crumb,
+.app-container.dark .artifact-detail-more {
+    color: #cbd5e1;
+}
+
+.app-container.dark .studio-back-btn:hover {
+    color: #fdba74;
+}
+
+.app-container.dark .mind-map-viewer {
+    background: linear-gradient(180deg, rgba(31, 24, 18, 0.96), rgba(15, 23, 42, 0.88));
+    border-color: rgba(251, 191, 36, 0.22);
+}
+
+.app-container.dark .mind-map-link {
+    stroke: #60a5fa;
+    opacity: 0.92;
+}
+
+.app-container.dark .mind-map-link.depth-1 {
+    stroke: #38bdf8;
+}
+
+.app-container.dark .mind-map-link.depth-2 {
+    stroke: #2dd4bf;
+}
+
+.app-container.dark .mind-map-link.depth-3,
+.app-container.dark .mind-map-link.depth-4 {
+    stroke: #86efac;
+}
+
+.app-container.dark .mind-graph-node {
+    background: #1e293b;
+    border-color: #334155;
+    color: #e5edf0;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.26);
+}
+
+.app-container.dark .mind-graph-node.depth-0 {
+    background: #312e81;
+    border-color: #6366f1;
+}
+
+.app-container.dark .mind-graph-node.depth-1 {
+    background: #1e3a5f;
+    border-color: #2563eb;
+}
+
+.app-container.dark .mind-graph-node.depth-2 {
+    background: #134e4a;
+    border-color: #14b8a6;
+}
+
+.app-container.dark .mind-graph-node.depth-3,
+.app-container.dark .mind-graph-node.depth-4 {
+    background: #14532d;
+    border-color: #22c55e;
+}
+
+.app-container.dark .mind-graph-count {
+    background: rgba(15, 23, 42, 0.8);
+    color: #bfdbfe;
 }
 
 .report-viewer {
@@ -1996,6 +2270,107 @@ body {
     font-weight: 650;
 }
 
+.app-container.dark .flashcard {
+    background: linear-gradient(135deg, #2a2118 0%, #1e293b 100%);
+    border-color: rgba(251, 191, 36, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.08);
+}
+
+.app-container.dark .flashcard.flipped {
+    background: linear-gradient(135deg, #1e1b4b 0%, #312e81 100%);
+    border-color: rgba(129, 140, 248, 0.36);
+}
+
+.app-container.dark .flashcard p,
+.app-container.dark .quiz-panel h4,
+.app-container.dark .takeaway-panel h4,
+.app-container.dark .report-section h3,
+.app-container.dark .infographic-section-item strong,
+.app-container.dark .faq-question {
+    color: #f8fafc;
+}
+
+.app-container.dark .flashcard-label,
+.app-container.dark .infographic-subtitle {
+    color: #cbd5e1;
+}
+
+.app-container.dark .flashcard-meta,
+.app-container.dark .infographic-section-item span,
+.app-container.dark .faq-question small {
+    color: #fdba74;
+}
+
+.app-container.dark .quiz-panel,
+.app-container.dark .report-section,
+.app-container.dark .takeaway-panel,
+.app-container.dark .infographic-section-item,
+.app-container.dark .faq-item {
+    background: rgba(15, 23, 42, 0.72);
+    border-color: rgba(148, 163, 184, 0.22);
+}
+
+.app-container.dark .quiz-score {
+    background: rgba(67, 20, 7, 0.78);
+    color: #fed7aa;
+}
+
+.app-container.dark .quiz-question,
+.app-container.dark .report-section p,
+.app-container.dark .takeaway-panel li,
+.app-container.dark .infographic-section-item p,
+.app-container.dark .faq-answer {
+    color: #dbe7ea;
+}
+
+.app-container.dark .quiz-option {
+    background: rgba(30, 41, 59, 0.9);
+    border-color: rgba(148, 163, 184, 0.24);
+    color: #e5edf0;
+}
+
+.app-container.dark .quiz-option.selected {
+    background: linear-gradient(135deg, #c2410c 0%, #ea580c 100%);
+    color: #fff7ed;
+}
+
+.app-container.dark .quiz-feedback.correct {
+    background: rgba(6, 78, 59, 0.58);
+    color: #bbf7d0;
+}
+
+.app-container.dark .quiz-feedback.wrong {
+    background: rgba(127, 29, 29, 0.5);
+    color: #fecaca;
+}
+
+.app-container.dark .report-summary {
+    background: rgba(67, 20, 7, 0.62);
+    color: #fed7aa;
+}
+
+.app-container.dark .infographic-frame,
+.app-container.dark .data-table-viewer {
+    background: rgba(15, 23, 42, 0.72);
+    border-color: rgba(148, 163, 184, 0.22);
+}
+
+.app-container.dark .data-table-viewer caption {
+    background: rgba(67, 20, 7, 0.62);
+    color: #fed7aa;
+}
+
+.app-container.dark .data-table-viewer th,
+.app-container.dark .data-table-viewer td {
+    border-bottom-color: rgba(148, 163, 184, 0.2);
+    color: #dbe7ea;
+}
+
+.app-container.dark .data-table-viewer th {
+    background: rgba(30, 41, 59, 0.94);
+    color: #f8fafc;
+}
+
 .placeholder-artifact {
     border-radius: 16px;
     border: 1px dashed rgba(249, 115, 22, 0.35);
@@ -2019,4 +2394,18 @@ body {
     color: #57534e;
     font-size: 0.84rem;
     line-height: 1.55;
+}
+
+.app-container.dark .placeholder-artifact {
+    background: linear-gradient(135deg, rgba(67, 20, 7, 0.62) 0%, rgba(15, 23, 42, 0.76) 100%);
+    border-color: rgba(251, 191, 36, 0.3);
+}
+
+.app-container.dark .placeholder-label {
+    background: rgba(30, 41, 59, 0.9);
+    color: #fdba74;
+}
+
+.app-container.dark .placeholder-artifact p {
+    color: #dbe7ea;
 }


### PR DESCRIPTION
## Summary
- Replace inline Studio artifact expansion with a dedicated detail view and back navigation.
- Render Mind Map artifacts as connected interactive graphs with clearer layout, accessible expandable nodes, and non-clickable leaves.
- Add dark-mode coverage, responsive detail layout fixes, persisted slide deck handoff, and regression tests for artifact viewers.

## Validation
- npm test -- --reporter=dot
- npm run build
- npm run lint (0 errors, existing warnings)
- npm run test:e2e -- --project=chromium
- python3 -m compileall -q backend
- python -m pytest -q
- live local smoke: backend + frontend, upload doc/L9.md, RAG chat, open Mind Map detail